### PR TITLE
skip certificate checking on wget to github https

### DIFF
--- a/lib/generators/vulcanize/templates/mysql/config/rubber/deploy-mysql.rb
+++ b/lib/generators/vulcanize/templates/mysql/config/rubber/deploy-mysql.rb
@@ -137,8 +137,8 @@ namespace :rubber do
     task :custom_install_munin, :roles => [:mysql_master, :mysql_slave] do
       rubber.sudo_script 'install_munin_mysql', <<-ENDSCRIPT
         if [ ! -f /usr/share/munin/plugins/mysql_ ]; then
-          wget -qN -O /usr/share/munin/plugins/mysql_ http://github.com/kjellm/munin-mysql/raw/master/mysql_
-          wget -qN -O /etc/munin/plugin-conf.d/mysql_.conf http://github.com/kjellm/munin-mysql/raw/master/mysql_.conf
+          wget --no-check-certificate -qN -O /usr/share/munin/plugins/mysql_ https://github.com/kjellm/munin-mysql/raw/master/mysql_
+          wget --no-check-certificate -qN -O /etc/munin/plugin-conf.d/mysql_.conf https://github.com/kjellm/munin-mysql/raw/master/mysql_.conf
         fi
       ENDSCRIPT
     end


### PR DESCRIPTION
The github url for the munin mysql config is now https and wget is not able to verify the authenticity for the certificate due to a known bug.

http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=409938
