### PR TITLE
Uses most recent passenger 3.0.0

### DIFF
--- a/lib/generators/vulcanize/templates/passenger/config/rubber/role/passenger/passenger-apache-vhost.conf
+++ b/lib/generators/vulcanize/templates/passenger/config/rubber/role/passenger/passenger-apache-vhost.conf
@@ -19,7 +19,6 @@ Listen <%= port %>
   SetEnvIf User-Agent "^(.*MSIE.*)|(.*AppleWebKit.*)$" nokeepalive
 
   RailsEnv  <%= RUBBER_ENV %>
-  RailsAllowModRewrite on
 
   RewriteEngine On
   RewriteCond %{HTTP_HOST} ^<%= rubber_env.domain %>$

--- a/lib/generators/vulcanize/templates/passenger/config/rubber/rubber-passenger.yml
+++ b/lib/generators/vulcanize/templates/passenger/config/rubber/rubber-passenger.yml
@@ -1,4 +1,4 @@
-passenger_version: 2.2.11
+passenger_version: 3.0.0
 passenger_root: "#{rvm_gem_home}/gems/passenger-#{passenger_version}"
 passenger_ruby: "#{ruby_prefix}/bin/passenger_ruby"
 passenger_lib: "#{passenger_root}/ext/apache2/mod_passenger.so"
@@ -11,5 +11,5 @@ role_dependencies:
 
 roles:
   passenger:
-    packages: [apache2-mpm-prefork, apache2-prefork-dev]
+    packages: [apache2-mpm-prefork, apache2-prefork-dev, libcurl4-openssl-dev]
     gems: [fastthread, rack, [passenger, "#{passenger_version}"]]


### PR DESCRIPTION
I'm using this configuration setup on my Ruuber scripts and since Passenger 3.0.0 is stable now, should be nice have it on the generators.
