### PR TITLE
Fix postgresql recipe

### DIFF
--- a/lib/generators/vulcanize/templates/postgresql/config/rubber/deploy-postgresql.rb
+++ b/lib/generators/vulcanize/templates/postgresql/config/rubber/deploy-postgresql.rb
@@ -7,7 +7,7 @@ namespace :rubber do
 
     before "rubber:install_packages", "rubber:postgresql:setup_apt_sources"
 
-    task :setup_apt_sources, :roles => :redis do
+    task :setup_apt_sources, :roles => [:postgresql_master, :postgresql_save] do
       rsudo "add-apt-repository ppa:pitti/postgresql"
     end
 


### PR DESCRIPTION
Hey there,

Thanks a lot for rubber - it's saving me a hell of a lot of grief! However, I noticed a little typo in the postgresql recipe - the setup_apt_sources is incorrectly specified to run on instances with the redis role, rather than the postgresql roles, causing the installation to fail. I've corrected this in my fork - Afraid I don't know where to begin writing a test for this, but am happy to give it a shot too if required.

Cheers!

Tim
