### PR TITLE
fix for rubber:util:local_to_ec2 and db restoration tasks

### DIFF
--- a/lib/rubber/tasks/rubber.rb
+++ b/lib/rubber/tasks/rubber.rb
@@ -262,7 +262,7 @@ namespace :rubber do
     raise "could not access backup file via s3" unless data
 
     puts "piping restore data to command [#{db_restore_cmd}]"
-    IO.popen(db_restore_cmd, mode='w') do |p|
+    IO.popen(db_restore_cmd, 'wb') do |p|
       data.value do |segment|
         p.write segment
       end


### PR DESCRIPTION
This was broken before because the gzip'd backup was not being treated as a binary. 
