### PR TITLE
Fix a problem where common_deps is sometimes nil

### DIFF
--- a/lib/rubber/instance.rb
+++ b/lib/rubber/instance.rb
@@ -158,7 +158,7 @@ module Rubber
 
         if expanded.size == 0
           common_deps = dependency_map[RoleItem.new('common')]
-          roles.concat(common_deps)
+          roles.concat(common_deps) unless common_deps.nil?
         end
 
         roles.each do |role|


### PR DESCRIPTION
I don't know why, but common_deps is sometimes nil, causing an array nil error to occur when I ran the cap rubber:create command. When I added this check in there, everything worked as expected. Is this shadowing a deeper underlying problem?
