### PR TITLE
Add @backup = false to mysql-proxy init.d script

### DIFF
--- a/lib/generators/vulcanize/templates/mysql_proxy/config/rubber/common/mysql-proxy
+++ b/lib/generators/vulcanize/templates/mysql_proxy/config/rubber/common/mysql-proxy
@@ -1,6 +1,7 @@
 <%
   @path = "/etc/init.d/mysql-proxy"
   @perms = 0755
+  @backup = false
 %>#! /bin/sh
 ### BEGIN INIT INFO
 # Provides:          mysql-proxy


### PR DESCRIPTION
Don't let rubber backup init.d scripts. Causes issues on startup.
