### PR TITLE
Ensure existence of mongodb path is checked before mkdir

### DIFF
--- a/lib/generators/vulcanize/templates/mongodb/config/rubber/deploy-mongodb.rb
+++ b/lib/generators/vulcanize/templates/mongodb/config/rubber/deploy-mongodb.rb
@@ -19,8 +19,12 @@ namespace :rubber do
     end
     
     task :setup_paths, :roles => :mongodb do
-      rsudo "mkdir -p #{rubber_env.mongodb_data_dir}"
-      rsudo "chown -R mongodb:mongodb #{rubber_env.mongodb_data_dir}"
+      rubber.sudo_script 'setup_mongodb_paths', <<-ENDSCRIPT
+        if [[ ! -d "#{rubber_env.mongodb_data_dir}" ]]; then
+          mkdir -p #{rubber_env.mongodb_data_dir}
+          chown -R mongodb:mongodb #{rubber_env.mongodb_data_dir}
+        fi
+      ENDSCRIPT
     end
     
     desc <<-DESC


### PR DESCRIPTION
My initial MongoDB commit didn't properly check for the existence of the MongoDB data directory before trying to create it. Attaching a fix. Sorry about that!
