### PR TITLE
Add mount_opts flag to volume hash to specify mount options

### DIFF
--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -124,7 +124,7 @@ namespace :rubber do
               fi
               mv /etc/fstab /etc/fstab.bak
               cat /etc/fstab.bak | grep -v '#{vol_spec['mount']}' > /etc/fstab
-              echo '#{vol_spec['device']} #{vol_spec['mount']} #{vol_spec['filesystem']} noatime 0 0 # rubber volume #{vol_id}' >> /etc/fstab
+              echo '#{vol_spec['device']} #{vol_spec['mount']} #{vol_spec['filesystem']} #{vol_spec['mount_opts'] ? vol_spec['mount_opts'] : 'noatime'} 0 0 # rubber volume #{vol_id}' >> /etc/fstab
 
               #{('yes | mkfs -t ' + vol_spec['filesystem'] + ' ' + vol_spec['device']) if created}
               #{("mkdir -p '#{vol_spec['mount']}'") if vol_spec['mount']}
@@ -222,7 +222,7 @@ namespace :rubber do
           fi
           mv /etc/fstab /etc/fstab.bak
           cat /etc/fstab.bak | grep -v '#{raid_spec['mount']}' > /etc/fstab
-          echo '#{raid_spec['device']} #{raid_spec['mount']} #{raid_spec['filesystem']} noatime 0 0 # rubber raid volume' >> /etc/fstab
+          echo '#{raid_spec['device']} #{raid_spec['mount']} #{raid_spec['filesystem']} #{vol_spec['mount_opts'] ? vol_spec['mount_opts'] : 'noatime'} 0 0 # rubber raid volume' >> /etc/fstab
 
           # seems to help devices initialize, otherwise mdadm fails because
           # device not ready even though ec2 says the volume is attached
@@ -287,7 +287,7 @@ namespace :rubber do
 
           mv /etc/fstab /etc/fstab.bak
           cat /etc/fstab.bak | grep -v '#{volume['mount']}\\b' > /etc/fstab
-          echo '#{device_name} #{volume['mount']} #{volume['filesystem']} noatime 0 0 # rubber LVM volume' >> /etc/fstab
+          echo '#{device_name} #{volume['mount']} #{volume['filesystem']} #{vol_spec['mount_opts'] ? vol_spec['mount_opts'] : 'noatime'} 0 0 # rubber LVM volume' >> /etc/fstab
         fi
 
         # Check if the logical volume exists or not.


### PR DESCRIPTION
I've added a mount_opts key to the volumes config hash that allows you to specify mount options in rubber.yml. This is especially useful for Mongo deploys since Mongo prefers its volumes to be mounted with noatime,noexec,nodiratime flags. The change is backwards compatible and reverts to the default noatime if there is no mount_opts key present.
