### PR TITLE
not escaping host name in monit-haproxy conf file can cause errors with syntax-like hosts.

### DIFF
--- a/lib/generators/vulcanize/templates/haproxy/config/rubber/role/haproxy/monit-haproxy.conf
+++ b/lib/generators/vulcanize/templates/haproxy/config/rubber/role/haproxy/monit-haproxy.conf
@@ -5,4 +5,4 @@ check process haproxy with pidfile /var/run/haproxy.pid
   group haproxy-<%= RUBBER_ENV %>
   start program = "/usr/bin/env service haproxy start"
   stop program = "/usr/bin/env service haproxy stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.haproxy_monitor_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.haproxy_monitor_port %> with timeout 10 seconds for 10 cycles then restart


### PR DESCRIPTION
need to put rubber_env.host in quotes to prevent host names that are also monit syntax from breaking the conf file.
