### PR TITLE
 rake rubber:restore_db_s3 restores the most recent file that in an S3 bucket, that matches the current environment

### DIFF
--- a/lib/rubber/tasks/rubber.rb
+++ b/lib/rubber/tasks/rubber.rb
@@ -258,7 +258,10 @@ namespace :rubber do
         data = s3objects.detect { |o| file == o.key }
       else
         puts "trying to fetch last modified s3 backup"
-        data = s3objects.max {|a,b| a.about["last-modified"] <=> b.about["last-modified"] }
+        # Only grab a file if the naming structure matches the current RUBBER_ENV
+        data = s3objects.select {|c| !c.key.match(/#{RUBBER_ENV}_dump_/).nil?  }.max do 
+          |a,b| a.about["last-modified"] <=> b.about["last-modified"]
+        end
       end
     end
     raise "could not access backup file via s3" unless data


### PR DESCRIPTION
Make sure that the latest file picked is in fact a backup of the correct RUBBER_ENV type; not just the most recent file of any time. Helpful if the same s3 bucket is being used for several things

On our project we are using the same S3 bucket for backing up both staging and production backups.
Our issue was that when we ran
- rake rubber:restore_db_s3
  It would restore the last backup regardless of whether it was a production backup or a staging backup.
  Given that this process is several layers removed from most of the developers, it took us a couple months before we realized what was going on.

This fix basically looks at a subset of files in the s3 bucket that match the current RUBBER_ENV, then picks the most recent version.
