### PR TITLE
Exit on load error hides information about some horrible dependency error

### DIFF
--- a/lib/rubber/dns/zerigo.rb
+++ b/lib/rubber/dns/zerigo.rb
@@ -4,7 +4,7 @@ begin
   require 'zerigo_dns'
 rescue LoadError
   puts "Missing the zerigo_dns gem.  Install with `sudo gem install zerigo_dns`."
-  exit(-1)
+  raise
 end
 
 module Rubber


### PR DESCRIPTION
Exit on load error hides information about some horrible dependency error between rubber 1.13.0 and zerigo_dns 1.2.0.
