### PR TITLE
Ensure Zerigo makes calls using XML in Rails 3.1

### DIFF
--- a/lib/rubber/dns/zerigo.rb
+++ b/lib/rubber/dns/zerigo.rb
@@ -17,6 +17,7 @@ module Rubber
 
         ::Zerigo::DNS::Base.user = provider_env.email
         ::Zerigo::DNS::Base.password = provider_env.token
+        ::Zerigo::DNS::Base.format = :xml
       end
 
       def host_to_opts(host)


### PR DESCRIPTION
This is related to issue #95. In Rails 3.1, Zerigo in Rubber is broken in two ways:

1) The Zerigo gem is overloading ActiveResource::Base, which added a second parameter in 3.1 and is therefore currently crashing. I've created a pull request to fix this issue on the Zerigo side.
2) ActiveResource's defaults were changed to use JSON over XML in 3.1. The enclosed patch ensures Zerigo always uses XML and is backwards compatible.
