### PR TITLE
Fix zerigo DNS

### DIFF
--- a/lib/rubber/dns/fog.rb
+++ b/lib/rubber/dns/fog.rb
@@ -10,6 +10,8 @@ module Rubber
       
       def initialize(env)
         super(env)
+        creds = Rubber::Util.symbolize_keys(env.credentials)
+        @client = ::Fog::DNS.new(creds)
       end
 
       def host_to_opts(host)

--- a/lib/rubber/dns/zerigo.rb
+++ b/lib/rubber/dns/zerigo.rb
@@ -8,13 +8,7 @@ module Rubber
     class Zerigo < Fog
 
       def initialize(env)
-        super(env)
-
-        @client = ::Fog::DNS.new({
-            :provider     => 'zerigo',
-            :zerigo_email => env.email,
-            :zerigo_token => env.token
-          })
+        super(env.merge({"credentials" => { "provider" => 'zerigo', "zerigo_email" => env.email, "zerigo_token" => env.token }}))
       end
     
     end


### PR DESCRIPTION
Resolves a couple of issues:

In lib/rubber/dns/zerigo.rb: 
*) Was missing an "end" for the module
*) Had a class/module conflict since it wasn't sure if it was inheriting from Rubber's fog class or the fog gem module
*) Using wrong variable for the zerigo email/key

In lib/rubber/dns/fog.rb:
*) zone.records.find would throw a Fog::DNS::Zerigo::NotFound exception if the fqdn wasn't found. Catching it into an empty array for now, although this should probably be better addressed in Fog somehow.
*) Was initializing an empty Fog::DNS client for classes that inherit this. Since the only DNS provider in Rubber currently using Fog is Zerigo, I've removed this for now. It basically meant one always would need to add a "credentials" section in rubber-dns.yml under every provider inheriting from Fog, even though each DNS provider in Fog has its own names for credentials.

Still need to update the comments in rubber-dns.yml to reflect this.
