### PR TITLE
Use nginx repo for much more current nginx

### DIFF
--- a/templates/nginx/config/rubber/deploy-nginx.rb
+++ b/templates/nginx/config/rubber/deploy-nginx.rb
@@ -2,8 +2,20 @@
 namespace :rubber do
 
   namespace :nginx do
-  
+    
     rubber.allow_optional_tasks(self)
+    
+    before "rubber:install_packages", "rubber:nginx:install"
+    
+    task :install, :roles => :nginx do
+      # Setup apt sources for current nginx
+      sources = <<-SOURCES
+        deb http://nginx.org/packages/ubuntu/ lucid nginx
+        deb-src http://nginx.org/packages/ubuntu/ lucid nginx
+      SOURCES
+      sources.gsub!(/^ */, '')
+      put(sources, "/etc/apt/sources.list.d/nginx.list")     
+    end
     
     # serial_task can only be called after roles defined - not normally a problem, but
     # rubber auto-roles don't get defined till after all tasks are defined


### PR DESCRIPTION
The Ubuntu apt source for nginx is awfully out of date. Use the official Nginx source to get the latest stable.
