### PR TITLE
Upload in 5mb chunks

### DIFF
--- a/lib/rubber/cloud/fog_storage.rb
+++ b/lib/rubber/cloud/fog_storage.rb
@@ -56,7 +56,7 @@ module Rubber
       def multipart_store(key, data, opts={})
         raise "a key is required" unless key && key.size > 0
         
-        opts = {:chunk_size => (5 * 10**6)}.merge(opts)
+        opts = {:chunk_size => (5242880)}.merge(opts)
   
         chunk = data.read(opts[:chunk_size])
   


### PR DESCRIPTION
S3 Database backups using Fog's multipart upload were failing with EntityTooSmall errors since the chunk size was less than 5MB, which is the S3 minimum.
