### PR TITLE
Properly replace app user variable for Unicorn

### DIFF
--- a/templates/unicorn/config/rubber/role/unicorn/unicorn.rb
+++ b/templates/unicorn/config/rubber/role/unicorn/unicorn.rb
@@ -55,7 +55,7 @@ after_fork do |server, worker|
   # drop the workers to www-data:www-data
   begin
     uid, gid = Process.euid, Process.egid
-    user, group = '#{rubber_env.app_user}', '#{rubber_env.app_user}'
+    user, group = '<%=rubber_env.app_user %>', '<%=rubber_env.app_user %>'
     target_uid = Etc.getpwnam(user).uid
     target_gid = Etc.getgrnam(group).gid
     worker.tmp.chown(target_uid, target_gid)


### PR DESCRIPTION
Unicorn's app runner wasn't being transformed due to typo
