### PR TITLE
Dont output empty environment variables into munin plugin conf

### DIFF
--- a/templates/munin/config/rubber/role/munin/munin-plugins.conf
+++ b/templates/munin/config/rubber/role/munin/munin-plugins.conf
@@ -5,7 +5,7 @@
 # munin-node clears out enviroment variables, so we need to add these in
 # to make sure we are running the correct ruby (rvm env vars, plus paths)
 [*]
-<%- ENV.select {|k, v| k =~ /rvm|ruby|bundler|gem|path/i }.each do |k, v| -%>
+<%- ENV.select {|k, v| k =~ /rvm|ruby|bundler|gem|path/i; v != "" }.each do |k, v| -%>
 env.<%= k %> <%= v %>
 <%- end -%>
 env.RUBYOPT rubygems


### PR DESCRIPTION
When munin encounters an empty environment variable in it's plugin conf, it barfs and stops processing the file.

Example: 

```
env.rvm_project_rvmrc 0
env.rvm_tmp_path /usr/local/rvm/tmp
env.GEM_PATH 
env.rvm_lib_path /usr/local/rvm/lib
```

Result: 
Line is not well formed (env.GEM_PATH) at /usr/share/perl5/Munin/Node/Service.pm line 81
 at /etc/munin/plugin-conf.d/rubber line 41. Skipping the rest of the file at /usr/share/perl5/Munin/Node/Service.pm line 81
