### PR TITLE
Wait an extra 2 secs after volume attachment to ensure ready

### DIFF
--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -109,7 +109,11 @@ namespace :rubber do
         print "."
         sleep 2
         volume = cloud.describe_volumes(vol_id).first
-        break if volume[:attachment_status] == "attached"
+        if volume[:attachment_status] == "attached"
+          print "."
+          sleep 2
+          break
+        end
       end
       print "\n"
 


### PR DESCRIPTION
After the switch to Fog, I've been running into an issue from the past almost constantly:

https://groups.google.com/d/topic/rubber-ec2/-wCn50X4i0M/discussion

Basically, Fog is really quick at attaching volumes, and the AWS describe-volumes API call is reporting volumes as attached before they are actually ready. This breaks RAID creation with error messages identical to the above thread. I just ran a test and this problem occurred 8 out of 10 times. After waiting an extra 2 seconds with the enclosed patch, the problem went away completely. If there's a more elegant solution, I'm all ears, but it looks like the AWS API is just lying in this case.
