### PR TITLE
Fix PostgreSQL slave db connection string.

### DIFF
--- a/templates/postgresql/config/rubber/role/postgresql_slave/recovery.conf
+++ b/templates/postgresql/config/rubber/role/postgresql_slave/recovery.conf
@@ -115,7 +115,7 @@ standby_mode = on
 # If set, the PostgreSQL server will try to connect to the primary using this
 # connection string and receive XLOG records continuously.
 #
-primary_conninfo = 'host=<%= rubber_instances.for_role('postgresql_master').first.name %> port=5432 user=<%= rubber_env.db_replication_user %> <%= rubber_env.db_replication_user_pass ? "password=#{rubber_env.db_replication_user}" : "" %> application_name=<%= rubber_env.app_name %>'		# e.g. 'host=localhost port=5432'
+primary_conninfo = 'host=<%= rubber_instances.for_role('postgresql_master').first.name %> port=5432 user=<%= rubber_env.db_replication_user %> <%= rubber_env.db_replication_pass ? "password=#{rubber_env.db_replication_pass}" : "" %> application_name=<%= rubber_env.app_name %>'		# e.g. 'host=localhost port=5432'
 #
 #
 # By default, a standby server keeps restoring XLOG records from the


### PR DESCRIPTION
The connection string included a non-existant var (db_replication_user_pass ) and then used the user var for the password instead of the correct password var (db_replication_pass).
