### PR TITLE
Use host name, not full host name, for web proxy suffixes

### DIFF
--- a/lib/rubber/recipes/rubber/setup.rb
+++ b/lib/rubber/recipes/rubber/setup.rb
@@ -408,7 +408,7 @@ namespace :rubber do
       # graphite web app)
       if instance_item.role_names.include?('web_tools')
         Array(rubber_env.web_tools_proxies).each do |name, settings|
-          provider.update("#{name}.#{instance_item.full_name}", instance_item.external_ip)
+          provider.update("#{name}.#{instance_item.name}", instance_item.external_ip)
         end
       end
     end
@@ -426,7 +426,7 @@ namespace :rubber do
       # graphite web app)
       if instance_item.role_names.include?('web_tools')
         Array(rubber_env.web_tools_proxies).each do |name, settings|
-          provider.destroy("#{name}.#{instance_item.full_name}")
+          provider.destroy("#{name}.#{instance_item.name}")
         end
       end
     end


### PR DESCRIPTION
When creating DNS records for web proxies, Rubber was affixing the domain name twice due to a typo. eg:

graylog.host.domain.com.domain.com

provider.update() already affixes the domain name itself, so no need to use full_name in these methods.
