### PR TITLE
explict path so jammit path isn't affected

### DIFF
--- a/templates/passenger/config/rubber/role/passenger/passenger-apache-vhost.conf
+++ b/templates/passenger/config/rubber/role/passenger/passenger-apache-vhost.conf
@@ -55,7 +55,7 @@ Listen <%= port %>
   # of compression than mod_deflate will, yielding savings all around.
 
   RewriteCond %{HTTP:Accept-Encoding} \b(x-)?gzip\b
-  RewriteCond <%= Rubber.root + "/public" %>%{REQUEST_FILENAME}.gz -s
+  RewriteCond <%= Rubber.root + "/public/assets" %>%{REQUEST_FILENAME}.gz -s
   RewriteRule ^(.+) $1.gz [L]
 
   <FilesMatch \.css\.gz$>


### PR DESCRIPTION
Simple fix to set the assets path more explicitly for rewriting the gzips.  Ran into this because it was conflicting my jammit configuration and serving non sprocket assets as gzipped files.
