### PR TITLE
added zip to redis package for backups

### DIFF
--- a/templates/redis/config/rubber/rubber-redis.yml
+++ b/templates/redis/config/rubber/rubber-redis.yml
@@ -14,4 +14,4 @@ role_dependencies:
 
 roles:
   redis:
-    packages: []
+    packages: [zip]


### PR DESCRIPTION
On a fresh instance, the cron job to backup redis kept failing because the zip package hadn't been installed.  This adds it to the rubber-redis yaml.
