### PR TITLE
Changed nginx.conf to only include tools.conf for instances with the role 'web_tools' 

### DIFF
--- a/templates/passenger_nginx/config/rubber/role/passenger_nginx/nginx.conf
+++ b/templates/passenger_nginx/config/rubber/role/passenger_nginx/nginx.conf
@@ -59,7 +59,7 @@ http
 	passenger_user <%= rubber_env.app_user %>;
 	
   include /etc/nginx/rubber/passenger_nginx.conf;
-  <% if rubber_instances.for_role('web_tools').first %>
+  <% if rubber_instances[rubber_env.host].role_names.include?('web_tools') %> 
     include /etc/nginx/rubber/tools.conf;
   <% end %>
 }


### PR DESCRIPTION
See the following thread where this change was discussed:

http://groups.google.com/group/rubber-ec2/browse_thread/thread/eec1856d5fd93eea/6d1ff6a3304d65bc?lnk=gst&q=role_names+web_tools#6d1ff6a3304d65bc
