### PR TITLE
Support to run web_tools with nginx on a separate instance

### DIFF
--- a/templates/complete_passenger_nginx/config/rubber/rubber-complete.yml
+++ b/templates/complete_passenger_nginx/config/rubber/rubber-complete.yml
@@ -1,6 +1,7 @@
 role_dependencies:
   web: [haproxy]
   app: [passenger_nginx]
+  web_tools: [passenger_nginx]
 
 web_port: 80
 web_ssl_port: 443


### PR DESCRIPTION
Changed passenger_nginx role dependencies so that web_tools can be run on a separate instance.
