### PR TITLE
Critical: Fix EBS Volume Mounting Issues

### DIFF
--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -136,7 +136,7 @@ namespace :rubber do
 		          # Ensure volume is ready before running mkfs on it.
 		          echo 'Waiting for device'
               cnt=0
-              while ! [[ -b #{vol_spec['device']} ]]; do
+              while ! [[ -b $device ]]; do
                 if [[ "$cnt" -eq "15" ]]; then
                   echo 'Timed out waiting for EBS device to be ready.'
                   mv /etc/fstab.bak /etc/fstab


### PR DESCRIPTION
Due to a stupid typo on my part, 2.0.4 broke volume mounting in Ubuntu 11+. This resolves the recent timeout issues reported on the mailing list. Also ensured that timed out volumes don't remain in the fstab, making this process idempotent again.
