### PR TITLE
sun-java6 fails on Ubuntu 10.04

### DIFF
--- a/templates/jenkins/config/rubber/rubber-jenkins.yml
+++ b/templates/jenkins/config/rubber/rubber-jenkins.yml
@@ -30,4 +30,4 @@ security_groups:
 roles:
   jenkins:
     assigned_security_groups: [jenkins_web]
-    packages: [sun-java6-jdk, jenkins]
+    packages: [openjdk-6-jdk, jenkins]


### PR DESCRIPTION
openjdk seems to work correctly but I've only used it on 10.04.  

AMIs:
32 bit   ami-4fd00726
64 bit   ami-35de095c
