### PR TITLE
Resque template fix

### DIFF
--- a/templates/resque/config/initializers/resque.rb
+++ b/templates/resque/config/initializers/resque.rb
@@ -4,7 +4,7 @@ redis_host = 'localhost:6379'
 resque_yml = Rubber.root.to_s + '/config/resque.yml'
 if File.exist? resque_yml
   resque_config = YAML.load_file(resque_yml)
-  redis_host = resque_config[rails_env]
+  redis_host = resque_config[Rubber.env]
 end
 
 Resque.redis = redis_host


### PR DESCRIPTION
I had problems adding the "resque" role to my servers.

The path to the resque.yml file would never work since Rubber.root was not being returned as a string

Also, I believe rails_env was changed to Rubber.env other places a while ago, but looks like it was missed in this template.
