### PR TITLE
Resque should connect to 'redis_master' role, rather than just 'redis' role.

### DIFF
--- a/templates/resque/config/rubber/common/resque.yml
+++ b/templates/resque/config/rubber/common/resque.yml
@@ -2,4 +2,4 @@
   @path = "#{Rubber.root}/config/resque.yml"
 %>
 
-<%= Rubber.env %>: <%= rubber_instances.for_role('redis').first.full_name rescue 'localhost' %>:6379
+<%= Rubber.env %>: <%= rubber_instances.for_role('redis_master').first.full_name rescue 'localhost' %>:6379


### PR DESCRIPTION
According to the [redis documentation](http://redis.io/topics/replication), Redis slaves are read-only by default.

The current form of the resque.yml file connects to just the 'redis' role, which includes slaves and masters.  This change make sure only masters will be used.
