### PR TITLE
Nettica DNS bug fix

### DIFF
--- a/lib/rubber/dns/nettica.rb
+++ b/lib/rubber/dns/nettica.rb
@@ -10,8 +10,8 @@ module Rubber
     class Nettica < Base
 
       def initialize(env)
-        super(env, "nettica")
-        @client = ::Nettica::Client.new(provider_env.user, provider_env.password)
+        super(env)
+        @client = ::Nettica::Client.new(env.user, env.password)
       end
 
       def check_status(response)


### PR DESCRIPTION
Hey there -- looks like the nettica DNS ruby file didn't get updated with one of the more recent refactors to its superclass (Rubber::DNS::Base) -- I fixed it and it works now.
