### PR TITLE
Unicorn isn't being restarted correctly

### DIFF
--- a/templates/unicorn/config/rubber/deploy-unicorn.rb
+++ b/templates/unicorn/config/rubber/deploy-unicorn.rb
@@ -27,7 +27,7 @@ namespace :rubber do
   
     desc "Reloads the unicorn web server"
     task :reload, :roles => :unicorn do
-      rsudo "if [ -f /var/run/unicorn.pid ]; then pid=`cat /var/run/unicorn.pid` && kill -USR2 $pid; else cd #{current_path} && bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D; fi"
+      rsudo "if [ -f /var/run/unicorn.pid ]; then pid=`cat /var/run/unicorn.pid` && kill -s USR2 $pid; else cd #{current_path} && bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D; fi"
     end
   
   end


### PR DESCRIPTION
Unicorn can be restarted if the master process is sent the signal "USR2".

However, the current way (kill -USR2 $pid) does not work.  This fix does things the correct way (kill -s USR2 $pid).
