### PR TITLE
Added sudo flag to change $HOME when running Postgresql commands

### DIFF
--- a/templates/postgresql/config/rubber/deploy-postgresql.rb
+++ b/templates/postgresql/config/rubber/deploy-postgresql.rb
@@ -1,4 +1,3 @@
-
 namespace :rubber do
   
   namespace :postgresql do
@@ -58,9 +57,9 @@ namespace :rubber do
             create_replication_user_cmd << " PASSWORD '#{env.db_replication_pass}'" if env.db_replication_pass
 
             rubber.sudo_script "create_master_db", <<-ENDSCRIPT
-              sudo -u postgres psql -c "#{create_user_cmd}"
-              sudo -u postgres psql -c "#{create_replication_user_cmd}"
-              sudo -u postgres psql -c "CREATE DATABASE #{env.db_name} WITH OWNER #{env.db_user}"
+              sudo -i -u postgres psql -c "#{create_user_cmd}"
+              sudo -i -u postgres psql -c "#{create_replication_user_cmd}"
+              sudo -i -u postgres psql -c "CREATE DATABASE #{env.db_name} WITH OWNER #{env.db_user}"
             ENDSCRIPT
           end
         end


### PR DESCRIPTION
If the shell is in /root immediately prior to running this script the psql client will try to initialize the Postgres client in that directory - throwing permissions errors.  This flag should remedy that.
