### PR TITLE
without disabling udev events, mdadm will not be able to create RAID array

### DIFF
--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -258,7 +258,9 @@ namespace :rubber do
           done
           echo 'Devices ready'
 
+          udevadm control --stop-exec-queue
           #{mdadm_init}
+          udevadm control --start-exec-queue
 
           # set reconstruction speed
           echo $((30*1024)) > /proc/sys/dev/raid/speed_limit_min


### PR DESCRIPTION
I was trying to build a RAID array using EBS volumes, and I was getting a "mdadm: ADD_NEW_DISK for /dev/XXXX failed: Device or resource busy" error.

After looking around, it appears that there is a recent problem with mdadm and Ubuntu 12.04.  There I already a bug filed (see link below).

This commit stops and then starts udev events, which allows the RAID array to be created.

https://bugs.launchpad.net/ubuntu/+source/mdadm/+bug/1030354
