### PR TITLE
Delete anonymous MySQL user when bootstrapping the db.

### DIFF
--- a/templates/mysql/config/rubber/deploy-mysql.rb
+++ b/templates/mysql/config/rubber/deploy-mysql.rb
@@ -40,6 +40,7 @@ namespace :rubber do
             pass = "identified by '#{env.db_pass}'" if env.db_pass
             rubber.sudo_script "create_master_db", <<-ENDSCRIPT
               mysql -u root -e "create database #{env.db_name};"
+              mysql -u root -e "delete from mysql.user where user='' and host='localhost';"
               mysql -u root -e "grant all on *.* to '#{env.db_user}'@'%' #{pass};"
               mysql -u root -e "grant select on *.* to '#{env.db_slave_user}'@'%' #{pass};"
               mysql -u root -e "grant replication slave on *.* to '#{env.db_replicator_user}'@'%' #{pass};"


### PR DESCRIPTION
This fixes #185. Deploying on Ubuntu 12.04 (which uses MySQL 5.5) resulted in errors similar to "Access denied for user ''@'localhost' to database 'cms_production'" during the db migration. See my comment in #185 for more details.
