### PR TITLE
Update Gemspec to take net-ssh ~> 2.6.0

### DIFF
--- a/rubber.gemspec
+++ b/rubber.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'capistrano', '~> 2.12'
   # TODO: force older version of net-ssh till connectivity issues with 2.5.x get resolved
-  s.add_dependency 'net-ssh', '~> 2.5.2'
+  s.add_dependency 'net-ssh', '~> 2.6.0'
   s.add_dependency 'thor'
   s.add_dependency 'clamp'
   s.add_dependency 'open4'


### PR DESCRIPTION
net-ssh was forced down to 2.4.x due to a bug.  Since then, 2.6.0 has been released and ideally would be used in order to reduce conflicts.
