### PR TITLE
Moved validation for creation of image

### DIFF
--- a/lib/rubber/cloud/aws.rb
+++ b/lib/rubber/cloud/aws.rb
@@ -28,19 +28,21 @@ module Rubber
       end
       
       def create_image(image_name)
-        ec2_key = env.key_file
-        ec2_pk = env.pk_file
-        ec2_cert = env.cert_file
-        ec2_key_dest = "/mnt/#{File.basename(ec2_key)}"
-        ec2_pk_dest = "/mnt/#{File.basename(ec2_pk)}"
-        ec2_cert_dest = "/mnt/#{File.basename(ec2_cert)}"
 
         # validate all needed config set
         ["key_file", "pk_file", "cert_file", "account", "secret_access_key", "image_bucket"].each do |k|
           raise "Set #{k} in rubber.yml" unless "#{env[k]}".strip.size > 0
         end
         raise "create_image can only be called from a capistrano scope" unless capistrano
-        
+ 
+        ec2_key = env.key_file
+        ec2_pk = env.pk_file
+        ec2_cert = env.cert_file
+
+        ec2_key_dest = "/mnt/#{File.basename(ec2_key)}"
+        ec2_pk_dest = "/mnt/#{File.basename(ec2_pk)}"
+        ec2_cert_dest = "/mnt/#{File.basename(ec2_cert)}"
+
         storage(env.image_bucket).ensure_bucket
         
         capistrano.put(File.read(ec2_key), ec2_key_dest)


### PR DESCRIPTION
When I ran "cap rubber:bundle", I saw the following error:

```
/Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/gems/rubber-2.1.2/lib/rubber/cloud/aws.rb:35:in `basename': can't convert nil into String (TypeError)
    from /Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/gems/rubber-2.1.2/lib/rubber/cloud/aws.rb:35:in `create_image'
    from /Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/gems/rubber-2.1.2/lib/rubber/thread_safe_proxy.rb:13:in `method_missing'
    from /Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/gems/rubber-2.1.2/lib/rubber/recipes/rubber/bundles.rb:9:in `block (2 levels) in 
...
```

On closer inspection, validation code is present in this method, but was not being applied before the first call (basename) that relied on the valid data. I have moved the validation to the top of the method.

Now, when the method is called without the required parameters, an exception is raised as expected:

```
peterson@rutan:~/code/test$ RUBBER_ENV=staging FILTER=staging-t1micro cap rubber:bundle
Respawning with 'bundle exec'
    triggering load callbacks
  * 2012-10-27 11:16:53 executing `rubber:init'
...
  * 2012-10-27 11:16:54 executing `rubber:bundle'
The image name for the bundle [20121027_1116]: staging-t1micro_20121027_1116
/Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/bundler/gems/rubber-39c3d4ebb24b/lib/rubber/cloud/aws.rb:34:in `block in create_image': Set pk_file in rubber.yml (RuntimeError)
    from /Users/peterson/.rvm/gems/ruby-1.9.3-p286@test/bundler/gems/rubber-39c3d4ebb24b/lib/rubber/cloud/aws.rb:33:in `each'
...
```
