### PR TITLE
Attach the configured elastic IP to rebooted instances

### DIFF
--- a/lib/rubber/recipes/rubber/static_ips.rb
+++ b/lib/rubber/recipes/rubber/static_ips.rb
@@ -19,8 +19,9 @@ namespace :rubber do
           rubber_instances.save
         end
 
-        # then, associate it if we don't have a record (on instance) of association
-        if ! ic.static_ip
+        # then, associate it if we don't have a record (on instance) of association or it
+        # doesn't match the instance's current external ip
+        if !ic.static_ip || ip != ic.external_ip
           logger.info "Associating static ip #{ip} with #{ic.full_name}"
           associate_static_ip(ip, ic.instance_id)
 


### PR DESCRIPTION
After rebooting an instance (`cap rubber:stop` and `cap rubber:start`) and refreshing the instance (`cap rubber:refresh`), the instance's save file will still have the old value for `static_ip` and a new, different value for `external_ip`.

This pull request will associate the elastic IP that the instance is configured to have during `post_refresh` by checking if the instance's saved external IP and its configured Elastic IP match and associating if they don't.
