### PR TITLE
Trigger rubber:config after deploy:update_code

### DIFF
--- a/lib/rubber/recipes/rubber/deploy.rb
+++ b/lib/rubber/recipes/rubber/deploy.rb
@@ -24,28 +24,30 @@ namespace :rubber do
   task :post_stop do
   end
 
-  # Don't want to do rubber:config for update_code as that tree isn't official
-  # until it is 'committed' by the symlink task (and doing so causes it to run
-  # for bootstrap_db which should only config the db config file).  However,
-  # deploy:migrations doesn't call update, so we need an additional trigger for
-  # it
-  after "deploy:update", "rubber:config"
+  after "deploy:update_code", "rubber:config"
   after "deploy:rollback_code", "rubber:config"
-  before "deploy:migrate", "rubber:config"
 
   desc <<-DESC
     Configures the deployed rails application by running the rubber configuration process
   DESC
   task :config do
-    opts = {}
-    opts[:no_post] = true if ENV['NO_POST']
-    opts[:force] = true if ENV['FORCE']
-    opts[:file] = ENV['FILE'] if ENV['FILE']
+    # Don't want to do rubber:config during bootstrap_db where it's triggered by
+    # deploy:update_code, because the user could be requiring the rails env inside
+    # some of their config templates (which fails because rails can't connect to
+    # the db)
+    if fetch(:rubber_updating_code_for_bootstrap_db, false)
+      logger.info "Updating code for bootstrap, skipping rubber:config"
+    else
+      opts = {}
+      opts[:no_post] = true if ENV['NO_POST']
+      opts[:force] = true if ENV['FORCE']
+      opts[:file] = ENV['FILE'] if ENV['FILE']
 
-    # when running deploy:migrations, we need to run config against release_path
-    opts[:deploy_path] = current_release if fetch(:migrate_target, :current).to_sym == :latest
+      # when running deploy:migrations, we need to run config against release_path
+      opts[:deploy_path] = current_release if fetch(:migrate_target, :current).to_sym == :latest
 
-    run_config(opts)
+      run_config(opts)
+    end
   end
 
   # because we start server as appserver user, but migrate as root, server needs to be able to write logs, etc.

--- a/lib/rubber/recipes/rubber/utils.rb
+++ b/lib/rubber/recipes/rubber/utils.rb
@@ -227,7 +227,10 @@ namespace :rubber do
   def update_code_for_bootstrap
     unless (fetch(:rubber_code_was_updated, false))
       deploy.setup
+      logger.info "updating code for bootstrap"
+      set :rubber_updating_code_for_bootstrap_db, true
       deploy.update_code
+      set :rubber_updating_code_for_bootstrap_db, false
     end
   end
   


### PR DESCRIPTION
Also added logic to skip `rubber:config` and `deploy:assets:precompile`
during db role bootstrapping.

This commit doesn't break normal deploys (including `deploy:migrations`
or `deploy:migrate`) with a deploy.rb file from old vulcanizations but
boostrap_db may fail if the assets task requires a database connection.
Re-vulcanizing to replace it with the new deploy.rb will fix it.

This will solve issue #258
