### PR TITLE
Properly handle dynamic roles in allow_optional_tasks

### DIFF
--- a/lib/rubber/recipes/rubber.rb
+++ b/lib/rubber/recipes/rubber.rb
@@ -28,8 +28,10 @@ namespace :rubber do
         # Disable connecting to any Windows instance.
         required_task(name, options.merge(:except => { :platform => 'windows' })) do
           # define empty roles for the case when a task has a role that we don't define anywhere
-          [*options[:roles]].each do |r|
-            roles[r] ||= []
+          unless options[:roles].respond_to?(:call)
+            [*options[:roles]].each do |r|
+              roles[r] ||= []
+            end
           end
           
           if find_servers_for_task(current_task).empty?


### PR DESCRIPTION
We can't splat a lambda, so we need to check for it when we are
defining a default empty role list. This resolves #252
