### PR TITLE
Dalli should be the default gem for memcached

### DIFF
--- a/templates/memcached/config/rubber/rubber-memcached.yml
+++ b/templates/memcached/config/rubber/rubber-memcached.yml
@@ -1,4 +1,4 @@
-# Sets up memcached server and client as cache_fu rails plugin (needs manual install into rails app)
+# Sets up memcached server and client as dalli
 
 gems: [dalli]
 


### PR DESCRIPTION
`memcache-client` has been deprecated since 2010, and `dalli` (written by same author as `memcache-client`) should be the default choice.
