### PR TITLE
Don't let rubber:nginx:start fail if the service is already running

### DIFF
--- a/templates/nginx/config/rubber/deploy-nginx.rb
+++ b/templates/nginx/config/rubber/deploy-nginx.rb
@@ -40,7 +40,7 @@ namespace :rubber do
     
     desc "Starts the nginx web server"
     task :start, :roles => :nginx do
-      rsudo "service nginx start || service nginx restart"
+      rsudo "service nginx status || service nginx start"
     end
     
     desc "Restarts the nginx web server"


### PR DESCRIPTION
If nginx is already running (automatically started after boot or
installation) then the rubber:nginx:start task will fail.

Before this, deploy:cold on a stopped/started instance would fail
during the deploy:start phase.
