### PR TITLE
Update to latest ruby-build

### DIFF
--- a/templates/base/config/rubber/rubber-ruby.yml
+++ b/templates/base/config/rubber/rubber-ruby.yml
@@ -11,7 +11,7 @@
 packages: [build-essential, git-core, subversion, curl, autoconf, bison, ruby, zlib1g-dev, libssl-dev, libreadline6-dev, libxml2-dev, libyaml-dev]
 
 # REQUIRED: The version of ruby-build to use for building ruby.
-ruby_build_version: 20130222
+ruby_build_version: 20130227
 
 # REQUIRED: Set to the version string for the ruby version you wish to use
 # Run "ruby-build --definitions" to see the list of possible options


### PR DESCRIPTION
Ruby 2.0.0-p0 is not available with the existing ruby-build; bumped it to make latest available but didn't bump default ruby ver
