### PR TITLE
Fixes #208

### DIFF
--- a/lib/rubber/recipes/rubber/security_groups.rb
+++ b/lib/rubber/recipes/rubber/security_groups.rb
@@ -131,6 +131,12 @@ namespace :rubber do
           end
         end
         
+        # Standardize the rules' format to reflect the format that the EC2 query returns
+        rules.collect! do |rule|
+          rule['source_group_account'].gsub!('-', '') if rule['source_group_account']
+          rule
+        end
+
         rule_maps = []
 
         # first collect the rule maps from the request (group/user pairs are duplicated for tcp/udp/icmp,


### PR DESCRIPTION
#208 is the result of the `cloud_providers.aws.account` being defined with hyphens (e.g. `5752-2269-6443`) in rubber.yml, which prevents it from matching the hyphen-less account IDs in the security group rules returned by AWS.

There's a comment in rubber.yml about this (`# REQUIRED The amazon keys and account ID (digits only, no dashes) used to access the AWS API`), but given the comment verbosity in that file, it's easy to overlook. AWS displays your account number with hyphens in their web interface, which is where most people probably copy it from.

This commit strips out those hyphens. It's sort of a judgement call about whether that rubber.yml comment is enough or not, so if you don't want to merge, no problem, but having this patch would've saved me (and I'm guessing @simo2409 and others, too) some debugging time.
