### PR TITLE
Remove 'text/html' from nginx gzip config to get rid of warning message.

### DIFF
--- a/templates/nginx/config/rubber/role/nginx/nginx.conf
+++ b/templates/nginx/config/rubber/role/nginx/nginx.conf
@@ -26,7 +26,7 @@ http
   gzip_http_version 1.0;
   gzip_comp_level   2;
   gzip_proxied      any;
-  gzip_types        text/plain text/html text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_types        text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
   # configure log format like to Apache's "combined" log format
   log_format        main


### PR DESCRIPTION
See http://wiki.nginx.org/HttpGzipModule#gzip_types

$ sudo service nginx start

nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/nginx.conf:26
