### PR TITLE
Added :status tasks

### DIFF
--- a/templates/collectd/config/rubber/deploy-collectd.rb
+++ b/templates/collectd/config/rubber/deploy-collectd.rb
@@ -45,8 +45,8 @@ namespace :rubber do
 
     desc "Display status of collectd system monitoring"
     task :status, :roles => :collectd do
-      rsudo "service collectd status"
-      rsudo "ps -eopid,user,fname | grep [c]ollectd"
+      rsudo "service collectd status || true"
+      rsudo "ps -eopid,user,fname | grep [c]ollectd || true"
     end
 
   end

--- a/templates/graphite/config/rubber/deploy-graphite.rb
+++ b/templates/graphite/config/rubber/deploy-graphite.rb
@@ -132,9 +132,9 @@ namespace :rubber do
 
       desc "Display status of graphite system monitoring"
       task :status, :roles => :graphite_server do
-        rsudo "service graphite-server status"
-        rsudo "ps -eopid,user,cmd | grep [c]arbon"
-        rsudo "sudo netstat -tupln | grep [p]ython"
+        rsudo "service graphite-server status || true"
+        rsudo "ps -eopid,user,cmd | grep [c]arbon || true"
+        rsudo "sudo netstat -tupln | grep [p]ython || true"
       end
 
     end
@@ -215,9 +215,9 @@ EOF
 
       desc "Display status of graphite web server"
       task :status, :roles => :graphite_web do
-        rsudo "service graphite-web status"
-        rsudo "ps -eopid,user,cmd | grep '[g]raphite/conf/uwsgi.ini'"
-        rsudo "netstat -tupln | grep uwsgi"
+        rsudo "service graphite-web status || true"
+        rsudo "ps -eopid,user,cmd | grep '[g]raphite/conf/uwsgi.ini' || true"
+        rsudo "netstat -tupln | grep uwsgi || true"
       end
 
     end

--- a/templates/memcached/config/rubber/deploy-memcached.rb
+++ b/templates/memcached/config/rubber/deploy-memcached.rb
@@ -5,8 +5,8 @@ namespace :rubber do
 
     desc "Display status of memcached shared memory"
     task :status, :roles => :memcached do
-      rsudo "ps -eopid,user,cmd | grep [m]emcached"
-      rsudo "netstat -tulpn | grep memcached"
+      rsudo "ps -eopid,user,cmd | grep [m]emcached || true"
+      rsudo "netstat -tulpn | grep memcached || true"
     end
 
   end

--- a/templates/mongodb/config/rubber/deploy-mongodb.rb
+++ b/templates/mongodb/config/rubber/deploy-mongodb.rb
@@ -55,9 +55,9 @@ namespace :rubber do
       Display status of the mongodb daemon
     DESC
     task :status, :roles => :mongodb do
-      rsudo "service mongodb status"
-      rsudo "ps -eopid,user,cmd | grep [m]ongod"
-      rsudo "netstat -tupan | grep mongod"
+      rsudo "service mongodb status || true"
+      rsudo "ps -eopid,user,cmd | grep [m]ongod || true"
+      rsudo "netstat -tupan | grep mongod || true"
     end
 
   end

--- a/templates/monit/config/rubber/deploy-monit.rb
+++ b/templates/monit/config/rubber/deploy-monit.rb
@@ -30,9 +30,9 @@ namespace :rubber do
 
     desc "Display status of monit daemon monitoring"
     task :status, :roles => :monit do
-      rsudo "service monit status"
-      rsudo "ps -eopid,user,fname | grep [m]onit"
-      rsudo "netstat -tulpn | grep monit"
+      rsudo "service monit status || true"
+      rsudo "ps -eopid,user,fname | grep [m]onit || true"
+      rsudo "netstat -tulpn | grep monit || true"
     end
 
   end

--- a/templates/nginx/config/rubber/deploy-nginx.rb
+++ b/templates/nginx/config/rubber/deploy-nginx.rb
@@ -55,9 +55,9 @@ namespace :rubber do
 
     desc "Display status of the nginx web server"
     task :status, :roles => :nginx do
-      rsudo "service nginx status"
-      rsudo "ps -eopid,user,fname | grep [n]ginx"
-      rsudo "netstat -tulpn | grep nginx"
+      rsudo "service nginx status || true"
+      rsudo "ps -eopid,user,fname | grep [n]ginx || true"
+      rsudo "netstat -tulpn | grep nginx || true"
     end
 
   end

--- a/templates/unicorn/config/rubber/deploy-unicorn.rb
+++ b/templates/unicorn/config/rubber/deploy-unicorn.rb
@@ -33,8 +33,8 @@ namespace :rubber do
     desc "Display status of the unicorn web server"
     task :status, :roles => :unicorn do
       # "service unicorn status" always returns "unicorn stop/waiting"
-      rsudo "ps -eopid,user,cmd | grep [u]nicorn"
-      rsudo "netstat -tupan | grep unicorn"
+      rsudo "ps -eopid,user,cmd | grep [u]nicorn || true"
+      rsudo "netstat -tupan | grep unicorn || true"
     end
 
   end


### PR DESCRIPTION
I've added status tasks for memcached, collectd, graphite, mongodb, monit, nginx, and unicorn.

These tasks display the following (where it is useful):
1) service status
2) process grep
3) netstat grep

I've found these very useful for quick troubleshooting, so I'm sharing them. Take it or leave it.
