### PR TITLE
Added :status commands

### DIFF
--- a/templates/collectd/config/rubber/deploy-collectd.rb
+++ b/templates/collectd/config/rubber/deploy-collectd.rb
@@ -43,6 +43,12 @@ namespace :rubber do
       rsudo "pkill -fn #{rubber_env.rubber_collectd_runner.sub(/./, '[\0]')} ; exit 0"
     end
 
+    desc "Display status of collectd system monitoring"
+    task :status, :roles => :collectd do
+      rsudo "service collectd status || true"
+      rsudo "ps -eopid,user,fname | grep [c]ollectd || true"
+    end
+
   end
 
 end

--- a/templates/graphite/config/rubber/deploy-graphite.rb
+++ b/templates/graphite/config/rubber/deploy-graphite.rb
@@ -129,6 +129,14 @@ namespace :rubber do
         stop
         start
       end
+
+      desc "Display status of graphite system monitoring"
+      task :status, :roles => :graphite_server do
+        rsudo "service graphite-server status || true"
+        rsudo "ps -eopid,user,cmd | grep [c]arbon || true"
+        rsudo "sudo netstat -tupln | grep [p]ython || true"
+      end
+
     end
 
     namespace :web do
@@ -189,20 +197,27 @@ EOF
         end
       end
 
-      desc "Start graphite system monitoring"
+      desc "Start graphite web server"
       task :start, :roles => :graphite_web do
         rsudo "service graphite-web status || service graphite-web start"
       end
 
-      desc "Stop graphite system monitoring"
+      desc "Stop graphite web server"
       task :stop, :roles => :graphite_web do
         rsudo "service graphite-web stop || true"
       end
 
-      desc "Restart graphite system monitoring"
+      desc "Restart graphite web server"
       task :restart, :roles => :graphite_web do
         stop
         start
+      end
+
+      desc "Display status of graphite web server"
+      task :status, :roles => :graphite_web do
+        rsudo "service graphite-web status || true"
+        rsudo "ps -eopid,user,cmd | grep '[g]raphite/conf/uwsgi.ini' || true"
+        rsudo "netstat -tupln | grep uwsgi || true"
       end
 
     end

--- a/templates/memcached/config/rubber/deploy-memcached.rb
+++ b/templates/memcached/config/rubber/deploy-memcached.rb
@@ -1,0 +1,15 @@
+
+namespace :rubber do
+  
+  namespace :memcached do
+
+    desc "Display status of memcached shared memory"
+    task :status, :roles => :memcached do
+      rsudo "service memcached status || true"
+      rsudo "ps -eopid,user,cmd | grep [m]emcached || true"
+      rsudo "netstat -tulpn | grep memcached || true"
+    end
+
+  end
+
+end

--- a/templates/mongodb/config/rubber/deploy-mongodb.rb
+++ b/templates/mongodb/config/rubber/deploy-mongodb.rb
@@ -50,7 +50,16 @@ namespace :rubber do
       stop
       start
     end
-    
+
+    desc <<-DESC
+      Display status of the mongodb daemon
+    DESC
+    task :status, :roles => :mongodb do
+      rsudo "service mongodb status || true"
+      rsudo "ps -eopid,user,cmd | grep [m]ongod || true"
+      rsudo "netstat -tupan | grep mongod || true"
+    end
+
   end
 
 end

--- a/templates/monit/config/rubber/deploy-monit.rb
+++ b/templates/monit/config/rubber/deploy-monit.rb
@@ -27,7 +27,14 @@ namespace :rubber do
       stop
       start
     end
-  
+
+    desc "Display status of monit daemon monitoring"
+    task :status, :roles => :monit do
+      rsudo "service monit status || true"
+      rsudo "ps -eopid,user,fname | grep [m]onit || true"
+      rsudo "netstat -tulpn | grep monit || true"
+    end
+
   end
 
 end

--- a/templates/nginx/config/rubber/deploy-nginx.rb
+++ b/templates/nginx/config/rubber/deploy-nginx.rb
@@ -52,7 +52,14 @@ namespace :rubber do
     task :reload, :roles => :nginx do
       serial_reload
     end
-  
+
+    desc "Display status of the nginx web server"
+    task :status, :roles => :nginx do
+      rsudo "service nginx status || true"
+      rsudo "ps -eopid,user,fname | grep [n]ginx || true"
+      rsudo "netstat -tulpn | grep nginx || true"
+    end
+
   end
 
 end

--- a/templates/unicorn/config/rubber/deploy-unicorn.rb
+++ b/templates/unicorn/config/rubber/deploy-unicorn.rb
@@ -29,7 +29,14 @@ namespace :rubber do
     task :reload, :roles => :unicorn do
       rsudo "if [ -f /var/run/unicorn.pid ]; then pid=`cat /var/run/unicorn.pid` && kill -USR2 $pid; else cd #{current_path} && bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D; fi"
     end
-  
+
+    desc "Display status of the unicorn web server"
+    task :status, :roles => :unicorn do
+      # "service unicorn status" always returns "unicorn stop/waiting"
+      rsudo "ps -eopid,user,cmd | grep [u]nicorn || true"
+      rsudo "netstat -tupan | grep unicorn || true"
+    end
+
   end
 
 end


### PR DESCRIPTION
Added :status commands for memcached, collectd, graphite, mongodb, monit, nginx, and unicorn.

These tasks display the following (where it is useful):
1) service status
2) process grep
3) netstat grep

I've found these useful for quick troubleshooting, so I'm sharing them. Take it or leave it.
