### PR TITLE
Opening up graphite_server port in AWS security groups

### DIFF
--- a/templates/graphite/config/rubber/rubber-graphite.yml
+++ b/templates/graphite/config/rubber/rubber-graphite.yml
@@ -22,3 +22,13 @@ roles:
     packages: [python-django, python-django-tagging, python-cairo, python-memcache, memcached, uwsgi, uwsgi-plugin-python, uwsgi-plugin-http, sqlite3, bzr, zip]
   collectd:
     packages: [libperl-dev]
+
+security_groups:
+  graphite_server:
+    description: "To open up port #{graphite_server_port} for graphite_server role"
+    rules:
+      - protocol: tcp
+        from_port: "#{graphite_server_port}"
+        to_port: "#{graphite_server_port}"
+        source_group_name: collectd
+        source_group_account: "#{cloud_providers.aws.account}"


### PR DESCRIPTION
I was getting collectd errors in a multi-instance environment until I opened up AWS port 2003 for graphite_server. I think this is required--please confirm.
