### PR TITLE
Remove conflicting passenger_min_instances.

### DIFF
--- a/templates/passenger_nginx/config/rubber/role/passenger_nginx/application.conf
+++ b/templates/passenger_nginx/config/rubber/role/passenger_nginx/application.conf
@@ -4,7 +4,6 @@
 
 server_name  <%= [ rubber_env.domain, rubber_env.web_aliases ].flatten.compact.join(" ") %>;
 passenger_enabled on;
-passenger_min_instances 1;
 passenger_set_cgi_param HTTP_X_QUEUE_START "t=${msec}000";
 
 root <%= Rubber.root + "/public" %>;


### PR DESCRIPTION
The setting `passenger_min_instances 1` in application.conf conflicts with the setting in nginx.conf. I believe the setting in nginx.conf is the desired value, as it's based on `rubber_env.max_app_connections`. I believe the desired behavior is to spawn all the worker processes at startup rather than starting them based on load (which incurs a delay each time a new worker starts).
