### PR TITLE
The create_master_db script needs to delete all blank users initially

### DIFF
--- a/templates/mysql/config/rubber/deploy-mysql.rb
+++ b/templates/mysql/config/rubber/deploy-mysql.rb
@@ -1,4 +1,3 @@
-
 namespace :rubber do
   
   namespace :mysql do
@@ -40,7 +39,7 @@ namespace :rubber do
             pass = "identified by '#{env.db_pass}'" if env.db_pass
             rubber.sudo_script "create_master_db", <<-ENDSCRIPT
               mysql -u root -e "create database #{env.db_name};"
-              mysql -u root -e "delete from mysql.user where user='' and host='localhost';"
+              mysql -u root -e "delete from mysql.user where user='';"
               mysql -u root -e "grant all on *.* to '#{env.db_user}'@'%' #{pass};"
               mysql -u root -e "grant select on *.* to '#{env.db_slave_user}'@'%' #{pass};"
               mysql -u root -e "grant replication slave on *.* to '#{env.db_replicator_user}'@'%' #{pass};"


### PR DESCRIPTION
Deleting `user=""` where `host="localhost"` doesn't seem to be enough, because deploying a new app with a different hostname will not have a host that is _literally_ `localhost`

Read the final comment here:

https://github.com/rubber/rubber/issues/185#issuecomment-8578399
