### PR TITLE
Add missing 'nginx_log_dir' setting to rubber-passenger_nginx.yml

### DIFF
--- a/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
+++ b/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
@@ -3,6 +3,7 @@ nginx_version: 1.2.8
 passenger_root: "#{`bash -l -c 'find #{ruby_path} -name passenger-#{passenger_version}'`.strip}"
 passenger_ruby: "#{ruby_path}/bin/ruby"
 passenger_lib: "#{passenger_root}/ext/nginx"
+nginx_log_dir: /mnt/nginx/logs
 passenger_listen_port: 7000
 passenger_listen_ssl_port: 7001
 max_app_connections: 20


### PR DESCRIPTION
#320 added a 'nginx_log_dir' setting to specify location of the Nginx log directory, but didn't add the new setting to all related yml files. I looked through the templates and I think that rubber-passenger_nginx.yml is the only other yml file effected.
