### PR TITLE
wait 2 minutes for tag creation

### DIFF
--- a/lib/rubber/cloud/aws.rb
+++ b/lib/rubber/cloud/aws.rb
@@ -75,7 +75,7 @@ module Rubber
       def after_create_instance(instance)
         # Sometimes tag creation will fail, indicating that the instance doesn't exist yet even though it does.  It seems to
         # be a propagation delay on Amazon's end, so the best we can do is wait and try again.
-        Rubber::Util.retry_on_failure(StandardError, :retry_sleep => 0.5, :retry_count => 100) do
+        Rubber::Util.retry_on_failure(StandardError, :retry_sleep => 1, :retry_count => 120) do
           Rubber::Tag::update_instance_tags(instance.name)
         end
       end
@@ -83,7 +83,7 @@ module Rubber
       def after_refresh_instance(instance)
         # Sometimes tag creation will fail, indicating that the instance doesn't exist yet even though it does.  It seems to
         # be a propagation delay on Amazon's end, so the best we can do is wait and try again.
-        Rubber::Util.retry_on_failure(StandardError, :retry_sleep => 0.5, :retry_count => 100) do
+        Rubber::Util.retry_on_failure(StandardError, :retry_sleep => 1, :retry_count => 120) do
           Rubber::Tag::update_instance_tags(instance.name)
         end
       end


### PR DESCRIPTION
Sometimes 50 seconds is not enough here.
From my numerous tests, I noticed that longer retry interval can help with "instance doesn't exist" issue.
Usually it takes 60-90 seconds.
2 minutes should be optimal for retry!
