### PR TITLE
only modify /etc/hosts (and ask for sudo) if it has changed

### DIFF
--- a/lib/rubber/recipes/rubber/setup.rb
+++ b/lib/rubber/recipes/rubber/setup.rb
@@ -124,11 +124,16 @@ namespace :rubber do
     local_hosts << delim << "\n"
 
     # Write out the hosts file for this machine, use sudo
-    filtered = File.read(hosts_file).gsub(/^#{delim}.*^#{delim}\n?/m, '')
-    logger.info "Writing out aliases into local machines #{hosts_file}, sudo access needed"
-    Rubber::Util::sudo_open(hosts_file, 'w') do |f|
-      f.write(filtered)
-      f.write(local_hosts)
+    existing = File.read(hosts_file)
+    filtered = existing.gsub(/^#{delim}.*^#{delim}\n?/m, '')
+
+    # only write out if it has changed
+    if existing != (filtered + local_hosts)
+      logger.info "Writing out aliases into local machines #{hosts_file}, sudo access needed"
+      Rubber::Util::sudo_open(hosts_file, 'w') do |f|
+        f.write(filtered)
+        f.write(local_hosts)
+      end
     end
   end
 


### PR DESCRIPTION
Hey Kevin/All,

While running `vagrant provision`, it asks the user to enter my system password.
This prevents me from going and getting coffee while the machine does the rubber magic.

This patch only asks the user for the system password if changes need to be made to /etc/hosts

Please pass across any suggestions.

Thanks,
Keenan
