### PR TITLE
Added nginx_log_dir: /mnt/nginx/logs to the rubber-passenger_nginx.yml

### DIFF
--- a/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
+++ b/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
@@ -6,6 +6,7 @@ passenger_lib: "#{passenger_root}/ext/nginx"
 passenger_listen_port: 7000
 passenger_listen_ssl_port: 7001
 max_app_connections: 20
+nginx_log_dir: /mnt/nginx/logs
 
 use_ssl_key: false
 #if you use an ssl key, put your cert and key


### PR DESCRIPTION
nginx_log_dir setting was missing from the rubber-passenger_nginx.yml file so it was causing a 

```
mkdir -p
```

issue when using complete_passenger_nginx_postgresql formula.
