### PR TITLE
Moved redis download link to redis.io 

### DIFF
--- a/templates/redis/config/rubber/deploy-redis.rb
+++ b/templates/redis/config/rubber/deploy-redis.rb
@@ -10,7 +10,7 @@ namespace :rubber do
       rubber.sudo_script 'install_redis', <<-ENDSCRIPT
         if ! redis-server --version | grep "#{rubber_env.redis_server_version}" &> /dev/null; then
           # Fetch the sources.
-          wget http://redis.googlecode.com/files/redis-#{rubber_env.redis_server_version}.tar.gz
+          wget http://download.redis.io/releases/redis-#{rubber_env.redis_server_version}.tar.gz
           tar -zxf redis-#{rubber_env.redis_server_version}.tar.gz
 
           # Build the binaries.
@@ -36,19 +36,19 @@ namespace :rubber do
     task :bootstrap, :roles => :redis do
       exists = capture("echo $(ls #{rubber_env.redis_db_dir} 2> /dev/null)")
       if exists.strip.size == 0
-        
+
         rubber.sudo_script 'bootstrap_redis', <<-ENDSCRIPT
           mkdir -p #{rubber_env.redis_db_dir}
           chown -R redis:redis #{rubber_env.redis_db_dir}
         ENDSCRIPT
-  
+
         # After everything installed on machines, we need the source tree
         # on hosts in order to run rubber:config for bootstrapping the db
         rubber.update_code_for_bootstrap
-  
+
         # Gen just the conf for redis.
         rubber.run_config(:file => "role/redis/", :force => true, :deploy_path => release_path)
-      
+
         restart
       end
     end


### PR DESCRIPTION
Google code link 404ed for 2.6.16.  I'm not 100% positive that redis.io has all versions.
