### PR TITLE
Enhances MySQL database.yml to respond to active environment, not just 'production'.

### DIFF
--- a/templates/mysql/config/rubber/common/database.yml
+++ b/templates/mysql/config/rubber/common/database.yml
@@ -3,7 +3,7 @@
 %>
 
 <%= Rubber.env %>:
-  adapter: <%= YAML::load(File.open("#{Rubber.root}/config/database.yml"))["production"]["adapter"] %>
+  adapter: <%= YAML::load(File.open("#{Rubber.root}/config/database.yml"))[Rubber.env]["adapter"] %>
   encoding: utf8
   database: <%= rubber_env.db_name %>
   username: <%= rubber_env.db_user %>


### PR DESCRIPTION
The production environment was assumed when determining the database adapter. The .yml template should use the rubber environment.

The original code causes a nill exception when using rubber like this:

`RAILS_ENV=staging ALIAS=staging cap deploy`
