### PR TITLE
Adds configuration of max memcached memory size through 'memcached_max_mem'

### DIFF
--- a/templates/memcached/config/rubber/role/memcached/memcached.conf
+++ b/templates/memcached/config/rubber/role/memcached/memcached.conf
@@ -6,7 +6,7 @@
 # memcached default config file edited for mobicious
 # 2003 - Jay Bonci <jaybonci@debian.org>
 # This configuration file is read by the start-memcached script provided as
-# part of the Debian GNU/Linux distribution. 
+# part of the Debian GNU/Linux distribution.
 
 # Run memcached as a daemon. This command is implied, and is not needed for the
 # daemon to run. See the README.Debian that comes with this package for more
@@ -25,10 +25,10 @@ logfile <%= rubber_env.memcached_log_dir %>/memcached.log
 # Start with a cap of 64 megs of memory. It's reasonable, and the daemon default
 # Note that the daemon will grow to this size, but does not start out holding this much
 # memory
--m 64
+-m <%= rubber_env.memcached_max_mem %>
 
 # Default connection port is 11211
--p 11211 
+-p 11211
 
 # Run the daemon as root. The start-memcached will default to running as root if no
 # -u command is present in this config file

--- a/templates/memcached/config/rubber/rubber-memcached.yml
+++ b/templates/memcached/config/rubber/rubber-memcached.yml
@@ -1,6 +1,7 @@
 # Sets up memcached server and client as dalli
 
 memcached_log_dir: /var/log/memcached
+memcached_max_mem:  64
 
 gems: [dalli]
 


### PR DESCRIPTION
I couldn't find a way to set the max memory memcached would use. It was defaulting to 65 MB, so I added this fix that is working well. 

The default remains at 64 MB so this change should be backward compatible.
