### PR TITLE
fixed ip_address deprecation for digital ocean

### DIFF
--- a/lib/rubber/cloud/digital_ocean.rb
+++ b/lib/rubber/cloud/digital_ocean.rb
@@ -79,8 +79,8 @@ module Rubber
           instance[:id] = item.id
           instance[:state] = item.state
           instance[:type] = item.flavor_id
-          instance[:external_ip] = item.ip_address
-          instance[:internal_ip] = item.ip_address
+          instance[:external_ip] = item.public_ip_address
+          instance[:internal_ip] = item.public_ip_address
           instance[:region_id] = item.region_id
           instance[:provider] = 'digital_ocean'
           instance[:platform] = 'linux'


### PR DESCRIPTION
While attempting to deploy to Digital Ocean, I received the message "ip_address has been deprecated. Use public_ip_address instead".  Cleverly, I searched this repository for "ip_address" and then changed it to "public_ip_address".
