### PR TITLE
Quote all `rubber_env.host` in Monit config template

### DIFF
--- a/templates/cassandra/config/rubber/role/cassandra/monit-cassandra.conf
+++ b/templates/cassandra/config/rubber/role/cassandra/monit-cassandra.conf
@@ -7,7 +7,7 @@ check process cassandra with pidfile <%= rubber_env.cassandra_pid_file %>
   group cassandra-<%= Rubber.env %>
   start program = "<%= rubber_env.cassandra_dir %>/bin/cassandra -p <%= rubber_env.cassandra_pid_file %>"
   stop program = "/bin/bash -l -c 'kill `cat <%= rubber_env.cassandra_pid_file %>`'"
-  #if failed host <%= rubber_env.host %> port <%= rubber_env.cassandra_rpc_port %> with timeout 10 seconds for 10 cycles then restart
+  #if failed host "<%= rubber_env.host %>" port <%= rubber_env.cassandra_rpc_port %> with timeout 10 seconds for 10 cycles then restart
 
 <% if Rubber.env == 'production' %>
 check filesystem commitlog_lv with path /mnt/cassandra/commitlog

--- a/templates/graphite/config/rubber/role/graphite_server/monit-graphite_server.conf
+++ b/templates/graphite/config/rubber/role/graphite_server/monit-graphite_server.conf
@@ -5,4 +5,4 @@ check process graphite_server with pidfile <%= rubber_env.graphite_server_pid_fi
   group graphite-<%= Rubber.env %>
   start program = "/usr/bin/env service graphite-server start"
   stop program = "/usr/bin/env service graphite-server stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.graphite_server_port %> with timeout 10 seconds for 3 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.graphite_server_port %> with timeout 10 seconds for 3 cycles then restart

--- a/templates/monit/config/rubber/role/cassandra/monit-cassandra.conf
+++ b/templates/monit/config/rubber/role/cassandra/monit-cassandra.conf
@@ -5,4 +5,4 @@ check process cassandra with pidfile <%= rubber_env.cassandra_pid_file %>
   group cassandra-<%= Rubber.env %>
   start program = "<%= rubber_env.cassandra_dir %>/bin/cassandra -p <%= rubber_env.cassandra_pid_file %>"
   stop program = "kill `cat <%= rubber_env.cassandra_pid_file %>`"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.cassandra_rpc_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.cassandra_rpc_port %> with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/elasticsearch/monit-elasticsearch.conf
+++ b/templates/monit/config/rubber/role/elasticsearch/monit-elasticsearch.conf
@@ -5,4 +5,4 @@ check process elasticsearch with pidfile <%= rubber_env.elasticsearch_pid_file %
   group elasticsearch-<%= Rubber.env %>
   start program = "/usr/bin/env service elasticsearch start"
   stop program = "/usr/bin/env service elasticsearch stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.elasticsearch_http_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.elasticsearch_http_port %> with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/graphite_server/monit-graphite_server.conf
+++ b/templates/monit/config/rubber/role/graphite_server/monit-graphite_server.conf
@@ -5,4 +5,4 @@ check process graphite_server with pidfile <%= rubber_env.graphite_server_pid_fi
   group graphite-<%= Rubber.env %>
   start program = "/usr/bin/env service graphite-server start"
   stop program = "/usr/bin/env service graphite-server stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.graphite_server_port %> with timeout 10 seconds for 3 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.graphite_server_port %> with timeout 10 seconds for 3 cycles then restart

--- a/templates/monit/config/rubber/role/graylog_server/monit-graylog_server.conf
+++ b/templates/monit/config/rubber/role/graylog_server/monit-graylog_server.conf
@@ -5,4 +5,4 @@ check process graylog_server with pidfile <%= rubber_env.graylog_server_pid_file
   group graylog-<%= Rubber.env %>
   start program = "/usr/bin/env service graylog-server start"
   stop program = "/usr/bin/env service graylog-server stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.graylog_server_port %> type UDP with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.graylog_server_port %> type UDP with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/graylog_web/monit-graylog_web.conf
+++ b/templates/monit/config/rubber/role/graylog_web/monit-graylog_web.conf
@@ -5,4 +5,4 @@ check process graylog_web with pidfile <%= rubber_env.graylog_web_pid_file %>
   group graylog-<%= Rubber.env %>
   start program = "/usr/bin/env service graylog-web start"
   stop program = "/usr/bin/env service graylog-web stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.graylog_web_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.graylog_web_port %> with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/jetty/monit-jetty.conf
+++ b/templates/monit/config/rubber/role/jetty/monit-jetty.conf
@@ -5,4 +5,4 @@ check process jetty with pidfile /var/run/jetty.pid
   group jetty-<%= Rubber.env %>
   start program = "<%= rubber_env.jetty_dir %>/bin/jetty.sh start"
   stop program = "<%= rubber_env.jetty_dir %>/bin/jetty.sh stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.jetty_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.jetty_port %> with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/mongrel/monit-mongrel.conf
+++ b/templates/monit/config/rubber/role/mongrel/monit-mongrel.conf
@@ -16,5 +16,5 @@
     stop program = "/bin/sh -c 'cd <%= Rubber.root %> && PATH=/usr/local/bin:$PATH && mongrel_rails cluster::stop --clean --only <%= port %> && sleep 30 && mongrel_rails cluster::stop --clean --force --only <%= port %>'"
     if totalmem > 200.0 MB for 3 cycles then restart
     <%# monit needs to test on same same interface that mongrel is listening on (see mongrel_cluster.yml) %>
-    if failed host <%= rubber_env.host %> port <%= port %> protocol http with timeout 10 seconds for 10 cycles then restart
+    if failed host "<%= rubber_env.host %>" port <%= port %> protocol http with timeout 10 seconds for 10 cycles then restart
 <% end %>

--- a/templates/monit/config/rubber/role/redis/monit-redis.conf
+++ b/templates/monit/config/rubber/role/redis/monit-redis.conf
@@ -5,4 +5,4 @@ check process redis with pidfile <%= rubber_env.redis_server_pid_file %>
   group redis-<%= Rubber.env %>
   start program = "/usr/bin/env service redis-server start"
   stop program = "/usr/bin/env service redis-server stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.redis_server_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.redis_server_port %> with timeout 10 seconds for 10 cycles then restart

--- a/templates/monit/config/rubber/role/sphinx/monit-sphinx.conf
+++ b/templates/monit/config/rubber/role/sphinx/monit-sphinx.conf
@@ -10,4 +10,4 @@ check process sphinx with pidfile <%= pidfile %>
   group sphinx-<%= Rubber.env %>
   start program = "/usr/bin/sudo -H -u <%= rubber_env.app_user %> bash -l -c '<%= start_program %>'"
   stop program = "/usr/bin/sudo -H -u <%= rubber_env.app_user %> bash -l -c '<%= stop_program %>'"
-  if failed host <%= rubber_env.host %> port 9312 with timeout 5 seconds for 5 cycles then restart
+  if failed host "<%= rubber_env.host %>" port 9312 with timeout 5 seconds for 5 cycles then restart

--- a/templates/torquebox/config/rubber/role/torquebox/monit-torquebox.conf
+++ b/templates/torquebox/config/rubber/role/torquebox/monit-torquebox.conf
@@ -5,4 +5,4 @@ check process torquebox with pidfile <%= rubber_env.torquebox_pid_file %>
   group torquebox-<%= Rubber.env %>
   start program = "/usr/bin/env service torquebox start"
   stop program = "/usr/bin/env service torquebox stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.torquebox_http_port %> with timeout 10 seconds for 20 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.torquebox_http_port %> with timeout 10 seconds for 20 cycles then restart

--- a/templates/zookeeper/config/rubber/role/zookeeper/monit-zookeeper.conf
+++ b/templates/zookeeper/config/rubber/role/zookeeper/monit-zookeeper.conf
@@ -5,4 +5,4 @@ check process zookeeper with pidfile <%= rubber_env.zookeeper_pid_file %>
   group zookeeper-<%= Rubber.env %>
   start program = "/usr/bin/env service zookeeper start"
   stop program = "/usr/bin/env service zookeeper stop"
-  if failed host <%= rubber_env.host %> port <%= rubber_env.zookeeper_client_port %> with timeout 10 seconds for 10 cycles then restart
+  if failed host "<%= rubber_env.host %>" port <%= rubber_env.zookeeper_client_port %> with timeout 10 seconds for 10 cycles then restart


### PR DESCRIPTION
I got an error when starting Monit
And fixed by quoting `rubber_env.host`
https://groups.google.com/forum/#!topic/rubber-ec2/e762wVWG-e4
So I think maybe the host in all Monit config files should be quoted

Similar to an old PR
https://github.com/rubber/rubber/pull/76
