### PR TITLE
Upgraded ruby version to address ruby security vulnerability CVE-2013-4164

### DIFF
--- a/templates/base/config/rubber/rubber-ruby.yml
+++ b/templates/base/config/rubber/rubber-ruby.yml
@@ -12,12 +12,12 @@ packages: [build-essential, git-core, subversion, curl, autoconf, bison, ruby, z
 
 # REQUIRED: The version of ruby-build to use for building ruby.
 # It must be one of the versions from https://github.com/sstephenson/ruby-build/blob/master/CHANGELOG.md
-ruby_build_version: 20131030
+ruby_build_version: 20131122.1
 
 # REQUIRED: Set to the version string for the ruby version you wish to use
 # Run "ruby-build --definitions" to see the list of possible options or look through the list of
 # recipes online at https://github.com/sstephenson/ruby-build/tree/master/share/ruby-build
-ruby_version: 1.9.3-p448
+ruby_version: 1.9.3-p484
 
 # REQUIRED: Installation path for ruby.
 ruby_path: "/usr/local/rubies/#{ruby_version}"


### PR DESCRIPTION
Hey there, noticed there was a ruby patch yesterday addressing a security vulnerability (CVE-2013-4164):

https://www.ruby-lang.org/en/news/2013/11/22/heap-overflow-in-floating-point-parsing-cve-2013-4164/

Ruby 2.0.0 users should set the ruby version to 2.0.0-p353
