### PR TITLE
fix vagrant 1.4.x sending array of ssh keys

### DIFF
--- a/lib/rubber/recipes/rubber.rb
+++ b/lib/rubber/recipes/rubber.rb
@@ -46,7 +46,7 @@ namespace :rubber do
               top.roles[r] ||= []
             end
           end
-          
+
           if find_servers_for_task(current_task).empty?
             logger.info "No servers for task #{name}, skipping"
             next
@@ -59,7 +59,7 @@ namespace :rubber do
 
   allow_optional_tasks(self)
   on :load, "rubber:init"
-    
+
   required_task :init do
     set :rubber_cfg, Rubber::Configuration.get_configuration(Rubber.env)
     set :rubber_env, rubber_cfg.environment.bind()
@@ -84,7 +84,14 @@ namespace :rubber do
     # the private key in the same folder, the public key should have the
     # extension ".pub".
 
-    ssh_options[:keys] = [ENV['RUBBER_SSH_KEY'] || cloud.env.key_file].flatten.compact
+    #ssh keys could be multiple, even from ENV. This is comma separated.
+    ssh_keys = if ENV['RUBBER_SSH_KEY']
+      ENV['RUBBER_SSH_KEY'].split(',')
+    else
+      cloud.env.key_file
+    end
+
+    ssh_options[:keys] = [ssh_keys].flatten.compact
     ssh_options[:timeout] = fetch(:ssh_timeout, 5)
   end
 

--- a/lib/rubber/vagrant/provisioner.rb
+++ b/lib/rubber/vagrant/provisioner.rb
@@ -29,14 +29,19 @@ module VagrantPlugins
 
       private
 
+      #comma separated ssh keys for rubber.
+      def rubber_ssh_keys
+        Array(ssh_info[:private_key_path]).join(',')
+      end
+
       def create
         if config.use_vagrant_ruby
-          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} ALIAS=#{machine.name} ROLES='#{config.roles}' EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} #{internal_cap_command} rubber:create -S initial_ssh_user=#{ssh_info[:username]}"
+          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} ALIAS=#{machine.name} ROLES='#{config.roles}' EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} RUBBER_SSH_KEY=#{rubber_ssh_keys} #{internal_cap_command} rubber:create -S initial_ssh_user=#{ssh_info[:username]}"
         else
           script = <<-ENDSCRIPT
             unset GEM_HOME;
             unset GEM_PATH;
-            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} ALIAS=#{machine.name} ROLES='#{config.roles}' EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} bash -c '#{rvm_prefix} bundle exec cap rubber:create -S initial_ssh_user=#{ssh_info[:username]}'
+            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} ALIAS=#{machine.name} ROLES='#{config.roles}' EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} RUBBER_SSH_KEY=#{rubber_ssh_keys} bash -c '#{rvm_prefix} bundle exec cap rubber:create -S initial_ssh_user=#{ssh_info[:username]}'
           ENDSCRIPT
         end
 
@@ -59,12 +64,12 @@ module VagrantPlugins
 
       def refresh
         if config.use_vagrant_ruby
-          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} ALIAS=#{machine.name} EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} #{internal_cap_command} rubber:refresh -S initial_ssh_user=#{ssh_info[:username]}"
+          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} ALIAS=#{machine.name} EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} #{internal_cap_command} rubber:refresh -S initial_ssh_user=#{ssh_info[:username]}"
         else
           script = <<-ENDSCRIPT
             unset GEM_HOME;
             unset GEM_PATH;
-            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} ALIAS=#{machine.name} EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} bash -c '#{rvm_prefix} bundle exec cap rubber:refresh -S initial_ssh_user=#{ssh_info[:username]}'
+            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} ALIAS=#{machine.name} EXTERNAL_IP=#{private_ip} INTERNAL_IP=#{private_ip} bash -c '#{rvm_prefix} bundle exec cap rubber:refresh -S initial_ssh_user=#{ssh_info[:username]}'
           ENDSCRIPT
         end
 
@@ -73,12 +78,12 @@ module VagrantPlugins
 
       def bootstrap
         if config.use_vagrant_ruby
-          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} FILTER=#{machine.name} #{internal_cap_command} rubber:bootstrap"
+          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} FILTER=#{machine.name} #{internal_cap_command} rubber:bootstrap"
         else
           script = <<-ENDSCRIPT
             unset GEM_HOME;
             unset GEM_PATH;
-            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} FILTER=#{machine.name} bash -c '#{rvm_prefix} bundle exec cap rubber:bootstrap'
+            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} FILTER=#{machine.name} bash -c '#{rvm_prefix} bundle exec cap rubber:bootstrap'
           ENDSCRIPT
         end
 
@@ -87,12 +92,12 @@ module VagrantPlugins
 
       def deploy_migrations
         if config.use_vagrant_ruby
-          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} FILTER=#{machine.name} #{internal_cap_command} deploy:migrations"
+          script = "RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} FILTER=#{machine.name} #{internal_cap_command} deploy:migrations"
         else
           script = <<-ENDSCRIPT
             unset GEM_HOME;
             unset GEM_PATH;
-            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{ssh_info[:private_key_path]} FILTER=#{machine.name} bash -c '#{rvm_prefix} bundle exec cap deploy:migrations'
+            PATH=#{ENV['PATH'].split(':')[1..-1].join(':')} RUN_FROM_VAGRANT=true RUBBER_ENV=#{config.rubber_env} RUBBER_SSH_KEY=#{rubber_ssh_keys} FILTER=#{machine.name} bash -c '#{rvm_prefix} bundle exec cap deploy:migrations'
           ENDSCRIPT
         end
 


### PR DESCRIPTION
Vagrant added the ability to have multiple private keys defined in mitchellh/vagrant#907.  In rubber, this changed the RUBBER_SSH_KEY env variable that the provisioner uses to pass through to the rubber commands, which it was just doing a .to_s on the array, resulting in an invalid path.

This changeset fixes that, and allows for multiple private keys to be passed in via the environment variable, comma separated.
