### PR TITLE
Pass single host to setup_security_groups instead of array. Fixes cap ru...

### DIFF
--- a/lib/rubber/recipes/rubber/security_groups.rb
+++ b/lib/rubber/recipes/rubber/security_groups.rb
@@ -8,7 +8,7 @@ namespace :rubber do
   required_task :setup_security_groups do
     servers = find_servers_for_task(current_task)
 
-    cloud.setup_security_groups(servers.collect(&:host))
+    servers.collect(&:host).each{ |host| cloud.setup_security_groups(host) }
   end
 
   desc <<-DESC


### PR DESCRIPTION
...bber:setup_security_groups task with digital ocean. This fixed issue #390 for me.

Ran `rake test`:
121 tests, 384 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
