### PR TITLE
Allow Travis failures on Ruby/JRuby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ matrix:
 
   allow_failures:
     - rvm: rbx-2
+    - rvm: 1.8.7
+    - rvm: jruby-18mode
 
 before_install:
   - gem install bundler -v '= 1.5.1'


### PR DESCRIPTION
Ruby 1.8.7 reached end-of-life 6 months ago. Currently Travis Ruby 1.8.7 builds are failing. I propose to allow them to fail and to drop official support for Ruby 1.8.7.
