### PR TITLE
Add rails 4 compatibility

### DIFF
--- a/templates/delayed_job/config/rubber/deploy-delayed_job.rb
+++ b/templates/delayed_job/config/rubber/deploy-delayed_job.rb
@@ -12,23 +12,26 @@ namespace :rubber do
       rubber_env.delayed_job_args || "-n #{rubber_env.num_delayed_job_workers}"
     end
 
-    def script_dir
-      File.directory?("bin") ? "bin" : "script"
+    def script_location
+      bin_location = "bin/delayed_job"
+      script_location = "script/delayed_job"
+
+      File.exists?(bin_location) ? bin_location : script_location
     end
  
     desc "Stop the delayed_job process"
     task :stop, :roles => :delayed_job do
-      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_dir}/delayed_job stop #{self.args}", :as => rubber_env.app_user
+      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_location} stop #{self.args}", :as => rubber_env.app_user
     end
  
     desc "Start the delayed_job process"
     task :start, :roles => :delayed_job do
-      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_dir}/delayed_job start #{self.args}", :as => rubber_env.app_user
+      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_location} start #{self.args}", :as => rubber_env.app_user
     end
  
     desc "Restart the delayed_job process"
     task :restart, :roles => :delayed_job do
-      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_dir}/delayed_job restart #{self.args}", :as => rubber_env.app_user
+      rsudo "cd #{current_path} && RAILS_ENV=#{Rubber.env} #{self.script_location} restart #{self.args}", :as => rubber_env.app_user
     end
  
     desc "Live tail of delayed_job log files for all machines"


### PR DESCRIPTION
Hi -
In Rails 4 delayed_job places scripts in the `bin/` instead of `scripts/`

This PR changes `templates/delayed_job/config/rubber/deploy-delayed_job.rb` to look at `bin/`
