### PR TITLE
Unable to sync security groups with source groups

### DIFF
--- a/lib/rubber/cloud/aws.rb
+++ b/lib/rubber/cloud/aws.rb
@@ -284,7 +284,14 @@ module Rubber
               rule[:source_groups] ||= []
               source_group = {}
               source_group[:account] = rule_group["userId"]
-              source_group[:name] = rule_group["groupName"]
+
+              if rule_group["groupName"]
+                source_group[:name] = rule_group["groupName"]
+              elsif rule_group["groupId"]
+                source_item = response.select{ |it| it.group_id == rule_group["groupId"] }.first
+                source_group[:name] = source_item ? source_item.name : nil
+              end
+
               rule[:source_groups] << source_group
             end if ip_item["groups"]
 


### PR DESCRIPTION
Given this security group definition in the rubber.yml file:

```
security_groups:
  default:
    rules:
      - protocol: tcp
        from_port: 1
        to_port: 65535
        source_group_name: default
        source_group_account: "#{cloud_providers.aws.account}"
```

Fog won't return the group name within the groups hash, so it won't get set. For Rubber, this looks like a different rule within that security group. Here's the rubber output when trying to sync:

```
  * Security Group already in cloud, syncing rules: default
Rule '{"protocol"=>"udp", "from_port"=>"1", "to_port"=>"65535", "source_group_name"=>"", "source_group_account"=>"123456789"}' exists in cloud, but not locally, remove from cloud? [y/N]:
```

Probably the "groupId" should be used to retrieve the name of the group from Fog's original response.
