### PR TITLE
Bugfix for obfuscated secret file location on remote servers

### DIFF
--- a/lib/rubber/environment.rb
+++ b/lib/rubber/environment.rb
@@ -52,6 +52,10 @@ module Rubber
         bound = bind()
         @config_secret = bound.rubber_secret
         if @config_secret
+
+          # Secret file is moved to config dir on remote servers
+          @config_secret = "#{@config_root}/#{File.basename(@config_secret)}" unless File.exist?(@config_secret)
+
           obfuscation_key = bound.rubber_secret_key
           if obfuscation_key
             require 'rubber/encryption'


### PR DESCRIPTION
Detect alternate location of secret file when it is moved into the `/config/rubber` dir on remote servers.

If you named your secret file as `/secret/rubber-secret.yml`, this would work by accident since it would be picked up by the `read_config method` (which reads all `rubber-xxx.yml` in the dif), not the `read_secret_config method`
