### PR TITLE
Unicorn improvements

### DIFF
--- a/templates/monit/config/rubber/role/unicorn/monit-unicorn.conf
+++ b/templates/monit/config/rubber/role/unicorn/monit-unicorn.conf
@@ -1,7 +1,7 @@
 <%
   @path = '/etc/monit/monit.d/monit-unicorn.conf'
 %>
-check process unicorn with pidfile /var/run/unicorn.pid
+check process unicorn with pidfile <%= rubber_env.unicorn_pid_file %>
   group unicorn-<%= Rubber.env %>
   start program = "/usr/bin/env service unicorn start"
   stop program = "/usr/bin/env service unicorn stop"

--- a/templates/unicorn/config/rubber/deploy-unicorn.rb
+++ b/templates/unicorn/config/rubber/deploy-unicorn.rb
@@ -7,16 +7,11 @@ namespace :rubber do
 
     before "deploy:stop", "rubber:unicorn:stop"
     after "deploy:start", "rubber:unicorn:start"
-    after "deploy:restart", "rubber:unicorn:reload"
+    after "deploy:restart", "rubber:unicorn:upgrade"
 
     desc "Stops the unicorn server"
     task :stop, :roles => :unicorn do
       rsudo "service unicorn stop"
-    end
-
-    desc "Forcefully kills the unicorn server"
-    task :force_stop, :roles => :unicorn do
-      rsudo "service unicorn force-stop"
     end
 
     desc "Starts the unicorn server"
@@ -30,16 +25,20 @@ namespace :rubber do
     end
 
     desc "Reloads the unicorn web server"
-    task :reload, :roles => :unicorn do
+    task :upgrade, :roles => :unicorn do
       rsudo "service unicorn upgrade"
     end
 
+    desc "Forcefully kills the unicorn server"
+    task :kill, :roles => :unicorn do
+      rsudo "service unicorn kill"
+    end
 
     desc "Display status of the unicorn web server"
     task :status, :roles => :unicorn do
-      # "service unicorn status" always returns "unicorn stop/waiting"
+      rsudo "service unicorn status || true"
       rsudo "ps -eopid,user,cmd | grep [u]nicorn || true"
-      rsudo "netstat -tupan | grep unicorn || true"
+      # rsudo "netstat -tupan | grep unicorn || true"
     end
 
   end

--- a/templates/unicorn/config/rubber/role/unicorn/unicorn
+++ b/templates/unicorn/config/rubber/role/unicorn/unicorn
@@ -10,9 +10,9 @@ set -e
 # since nginx and unicorn accept the same signals
 
 # Feel free to change any of the following variables for your app:
-TIMEOUT=${TIMEOUT-60}
+TIMEOUT=${TIMEOUT-600}
 APP_ROOT=<%= current_path %>
-PID=/var/run/unicorn.pid
+PID=<%= rubber_env.unicorn_pid_file %>
 CMD="<%= "bundle exec unicorn_rails -c #{current_path}/config/unicorn.rb -E #{Rubber.env} -D" %>"
 action="$1"
 set -u
@@ -38,7 +38,7 @@ stop)
   sig QUIT && exit 0
   echo >&2 "Not running"
   ;;
-force-stop)
+kill)
   sig TERM && exit 0
   echo >&2 "Not running"
   ;;
@@ -50,42 +50,52 @@ restart|reload)
 upgrade)
   if sig USR2
   then
-    printf 'Waiting for new workers'
+    printf 'Waiting for new Unicorn workers'
     n=$TIMEOUT
     while (! (test -s $PID && ps --no-headers --ppid `cat $PID` > /dev/null)) && test $n -ge 0
     do
-      printf '.' && sleep 1 && n=$(( $n - 1 ))
+      printf '.' && sleep 10 && n=$(( $n - 10 ))
     done
-    if test ! -s $old_pid
+
+    if test $n -lt 0 && (! (test -s $PID && ps --no-headers --ppid `cat $PID` > /dev/null))
     then
+      echo >&2 "$PID process does not exist after $TIMEOUT seconds"
+      exit 1
+    fi
+    printf '\nNew Unicorn workers started'
+
+    if test -s $old_pid
+    then
+      printf '\nWaiting for old Unicorn master to stop'
+      n=$TIMEOUT
+      while test -s $old_pid && test $n -ge 0
+      do
+        printf '.' && sleep 10 && n=$(( $n - 10 ))
+      done
       echo
-      echo >&2 'New workers failed to start; see error log'
-      exit 1
-    fi
-    printf '\nStopping old master' && oldsig QUIT
 
-    n=$TIMEOUT
-    while test -s $old_pid && test $n -ge 0
-    do
-      printf '.' && sleep 1 && n=$(( $n - 1 ))
-    done
-    echo
-
-    if test $n -lt 0 && test -s $old_pid
-    then
-      echo >&2 "$old_pid still exists after $TIMEOUT seconds"
-      exit 1
+      if test $n -lt 0 && test -s $old_pid
+      then
+        echo >&2 "$old_pid still exists after $TIMEOUT seconds"
+        exit 1
+      fi
     fi
+
+    printf '\nOld Unicorn master stopped'
     exit 0
   fi
   echo >&2 "Couldn't upgrade, starting '$CMD' instead"
   $CMD
   ;;
+status)
+  sig 0 && echo >&2 "Running" && exit 1
+  echo >&2 "Stopped" && exit 0
+  ;;
 reopen-logs)
   sig USR1
   ;;
 *)
-  echo >&2 "Usage: $0 <start|stop|restart|upgrade|force-stop|reopen-logs>"
+  echo >&2 "Usage: $0 <start|stop|restart|upgrade|kill|status|reopen-logs>"
   exit 1
   ;;
 esac

--- a/templates/unicorn/config/rubber/rubber-unicorn.yml
+++ b/templates/unicorn/config/rubber/rubber-unicorn.yml
@@ -1,3 +1,6 @@
+unicorn_num_workers: 2
+unicorn_pid_file: /var/run/unicorn.pid
+
 role_dependencies:
   unicorn: [nginx]
 roles:


### PR DESCRIPTION
This PR contains a number of improvements on top of @ScotterC's Unicorn PR #419. The biggest change is that the Unicorn upgrade process is now safe for heavier apps that take a longer time to restart; previously it could timeout or fail to start workers appropriately. There are also some nomenclature/error msg standardization and increase in configurability.
