### PR TITLE
should no longer hang on stop

### DIFF
--- a/templates/graphite/config/rubber/role/graphite_server/graphite_server-upstart.conf
+++ b/templates/graphite/config/rubber/role/graphite_server/graphite_server-upstart.conf
@@ -4,13 +4,20 @@
 %>
 description "graphite server"
 
-start on [2345]
-stop on runlevel [016]
+start on runlevel [2345]
+stop on runlevel [!2345]
 
-expect daemon
+env CARBON_CACHE=<%= rubber_env.graphite_dir %>/bin/carbon-cache.py
+env PIDFILE=/var/run/graphite-server.pid
+env LOGDIR=<%= rubber_env.graphite_storage_dir %>/log/carbon-cache
+
+kill timeout 5
+
+post-stop exec $CARBON_CACHE --pidfile=$PIDFILE --debug stop
 
 script
-  cd <%= rubber_env.graphite_dir %>
-  rm -f <%= rubber_env.graphite_server_pid_file %>
-  exec ./bin/carbon-cache.py --pidfile <%= rubber_env.graphite_server_pid_file %> start
+  ulimit -n 65000
+
+  mkdir -p $LOGDIR
+  exec $CARBON_CACHE --pidfile=$PIDFILE --debug start >> $LOGDIR/console.log 2>&1
 end script


### PR DESCRIPTION
This fixes an issue where stopping the graphite service would hang.  I tested rubber:graphite:server:stop, start, and restart on a vagrant VM and all seemed to work
