### PR TITLE
GitHub Hubot robot template

### DIFF
--- a/templates/hubot/config/rubber/deploy-hubot.rb
+++ b/templates/hubot/config/rubber/deploy-hubot.rb
@@ -1,0 +1,46 @@
+namespace :rubber do
+
+  namespace :hubot do
+
+    rubber.allow_optional_tasks(self)
+
+    after "rubber:node:install", "rubber:hubot:install"
+
+    task :install, :roles => :hubot do
+      rubber.run_script 'install_hubot', <<-ENDSCRIPT
+      if [ ! -d "#{rubber_env.hubot_home}" ];then
+        $(id  #{rubber_env.hubot_user} > /dev/null 2>&1)||useradd --shell /bin/false -M #{rubber_env.hubot_user}
+        #{rubber_env.node_prefix}/bin/npm install -g coffee-script
+        #{rubber_env.node_prefix}/bin/npm install -g hubot@#{rubber_env.hubot_version}
+        cd #{rubber_env.hubot_prefix} && git clone #{rubber_env.hubot_git_url}
+        #{rubber_env.node_prefix}/bin/npm install --save hubot-hipchat
+      fi
+      ENDSCRIPT
+    end
+
+    task :bootstrap, :roles => :hubot do
+      rubber.run "cd #{rubber_env.hubot_home} && git pull"
+      rubber.update_code_for_bootstrap
+      rubber.run_config(:file => "role/hubot", :force => true, :deploy_path => release_path)
+      restart
+    end
+
+    desc "Stops Hubot"
+    task :stop, :roles => :hubot, :on_error => :continue do
+      rsudo "service hubot stop || true"
+    end
+
+    desc "Starts Hubot"
+    task :start, :roles => :hubot do
+      rsudo "service hubot start"
+    end
+
+    desc "Restarts Hubot"
+    task :restart, :roles => :hubot do
+      stop
+      start
+    end
+
+  end
+
+end

--- a/templates/hubot/config/rubber/role/hubot/hubot
+++ b/templates/hubot/config/rubber/role/hubot/hubot
@@ -1,0 +1,15 @@
+<%
+  @path = "#{rubber_env.hubot_home}/bin/hubot"
+  @perms = 0750
+  @owner = "hubot"
+%>#!/bin/bash
+
+npm install
+export PORT=9393
+export PATH="<%= rubber_env.hubot_home %>/node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
+
+export HUBOT_HIPCHAT_ROOMS="<%= rubber_env.hubot_hipchat_rooms %>"
+export HUBOT_HIPCHAT_JID="<%= rubber_env.hubot_hipchat_jid %>"
+export HUBOT_HIPCHAT_PASSWORD="<%= rubber_env.hubot_hipchat_password %>"
+
+exec <%= rubber_env.hubot_home %>/node_modules/.bin/hubot -a hipchat "$@"

--- a/templates/hubot/config/rubber/role/hubot/hubot_bin.conf
+++ b/templates/hubot/config/rubber/role/hubot/hubot_bin.conf
@@ -1,0 +1,15 @@
+<%
+  @path = "#{rubber_env.hubot_home}/bin/hubot"
+  @perms = 0700
+  @owner = "hubot"
+%>#!/bin/bash
+
+npm install
+export PORT=9393
+export PATH="<%= rubber_env.hubot_home %>/node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
+
+export HUBOT_HIPCHAT_ROOMS="<%= rubber_env.hubot_hipchat_rooms %>"
+export HUBOT_HIPCHAT_JID="<%= rubber_env.hubot_hipchat_jid %>"
+export HUBOT_HIPCHAT_PASSWORD="<%= rubber_env.hubot_hipchat_password %>"
+
+exec <%= rubber_env.hubot_home %>/node_modules/.bin/hubot -a hipchat "$@"

--- a/templates/hubot/config/rubber/role/hubot/hubot_startup.conf
+++ b/templates/hubot/config/rubber/role/hubot/hubot_startup.conf
@@ -1,0 +1,56 @@
+<%
+  @path = "/etc/init.d/hubot"
+  @perms = 0755
+%>#!/bin/sh
+
+# This assumes you have:
+# 1) A user called `hubot` in charge of the bot.
+# 2) A file called $HUBOT_HOME/bin/hubot that contains the Hubot env info
+#
+#
+### BEGIN INIT INFO
+# Provides:          hubot
+# Required-Start:    $all
+# Required-Stop:     $all
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: starts the hubot service
+# Description:       starts the Hubot bot for the Hipchat rooms
+### END INIT INFO
+
+NAME="hubot"
+HUBOT_HOME="<%= rubber_env.hubot_home %>"
+LOGFILE="/var/log/hubot.log"
+
+set -e
+
+case "$1" in
+   start)
+        echo -n "Starting $NAME: "
+        cd $HUBOT_HOME
+        nohup su -c "$HUBOT_HOME/bin/hubot" -s /bin/sh "$NAME" > $LOGFILE 2>&1 &
+        echo "."
+        ;;
+   stop)
+        PID=`ps -efa | grep 'node_modules/hubot' | grep -v grep | awk {'print $2'}`
+        echo -n "Stopping $NAME: "
+        if [ -z $PID ];then
+          echo "PID doesn't exist. Hubot is probably not running... "
+        else
+          kill -9 $PID
+        fi
+        echo "."
+        ;;
+   restart)
+        echo -n "Restarting $NAME: "
+        /etc/init.d/$NAME stop
+        /etc/init.d/$NAME start
+        echo "."
+        ;;
+    *)
+        N=/etc/init.d/$NAME
+        echo "Usage: $N {start|stop}" >&2
+        exit 1
+        ;;
+    esac
+    exit

--- a/templates/hubot/config/rubber/role/hubot/monit-hubot.conf
+++ b/templates/hubot/config/rubber/role/hubot/monit-hubot.conf
@@ -1,0 +1,7 @@
+<%
+  @path = '/etc/monit/monit.d/monit-hubot.conf'
+%>
+check process hubot matching "node_modules/hubot"
+   start program = "/etc/init.d/hubot start"
+   stop  program = "/etc/init.d/hubot stop"
+   #if 5 restarts within 5 cycles then timeout

--- a/templates/hubot/config/rubber/rubber-hubot.yml
+++ b/templates/hubot/config/rubber/rubber-hubot.yml
@@ -1,0 +1,15 @@
+hubot_version: 'v2.5.1'
+hubot_hipchat_rooms: ''
+hubot_hipchat_jid: ''
+hubot_hipchat_password: ''
+hubot_prefix: '/opt'
+hubot_home: '/opt/hubot'
+hubot_user: 'hubot'
+hubot_git_url: ''
+
+role_dependencies:
+  hubot: [node, redis]
+
+roles:
+  hubot:
+    packages: [python-software-properties, build-essential, libssl-dev, libexpat1-dev]

--- a/templates/hubot/templates.yml
+++ b/templates/hubot/templates.yml
@@ -1,0 +1,1 @@
+description: GitHub Hubot robot module 


### PR DESCRIPTION
This is a Rubber template for GitHub Hubot with Hipchat integration.
It assumes that you have created your Hubot Git repo as described in Hubot docs getting started docs:
https://github.com/github/hubot/tree/master/docs. Hubot Git repo URL parameter 'hubot_git_url' should be set in rubber-hubot.yml.

Template was tested on Ubuntu 12.04 LTS. It requires Node v0.10 and Redis server installed. Redis is required to support Hubot redis backend, which is used by redis-brain.coffee script. 
If you don't want to use redis backend, remove :redis-brain.coffee" script reference from hubot-scripts.json. 
