### PR TITLE
add newrelic aws cloudwatch agent

### DIFF
--- a/templates/newrelic_aws_cloudwatch/config/rubber/deploy-newrelic_aws_cloudwatch.rb
+++ b/templates/newrelic_aws_cloudwatch/config/rubber/deploy-newrelic_aws_cloudwatch.rb
@@ -1,0 +1,51 @@
+#https://github.com/newrelic-platform/newrelic_aws_cloudwatch_plugin
+namespace :rubber do
+  namespace :newrelic_aws_cloudwatch do
+
+    rubber.allow_optional_tasks(self)
+
+    after "rubber:install_packages", "rubber:newrelic_aws_cloudwatch:install"
+
+    task :install, :roles => :newrelic_aws_cloudwatch do
+      #todo check installed version?
+      rubber.sudo_script 'install_newrelic_aws_cloudwatch', <<-ENDSCRIPT
+      cw=`pwd`
+
+      wget https://github.com/newrelic-platform/newrelic_aws_cloudwatch_plugin/archive/latest.tar.gz
+      mkdir -p #{rubber_env.newrelic_aws_cloudwatch_home}
+
+      tar -zxf latest.tar.gz
+      dir=(newrelic_aws_cloudwatch_plugin*)
+      nr_dir=${dir[@]:0:1}
+      cp -a $nr_dir/* #{rubber_env.newrelic_aws_cloudwatch_home}/
+      cd #{rubber_env.newrelic_aws_cloudwatch_home}
+      bundle install
+
+      cd $cw
+      rm -r $nr_dir
+      rm latest.tar.gz
+      ENDSCRIPT
+    end
+
+    before "deploy:stop", "rubber:newrelic_aws_cloudwatch:stop"
+    after "deploy:start", "rubber:newrelic_aws_cloudwatch:start"
+    after "deploy:restart", "rubber:newrelic_aws_cloudwatch:restart"
+
+    desc "Stops the newrelic_aws_cloudwatch"
+    task :stop, :roles => :newrelic_aws_cloudwatch do
+      rsudo "service newrelic_aws_cloudwatch stop || true"
+    end
+
+    desc "Starts the newrelic_aws_cloudwatch"
+    task :start, :roles => :newrelic_aws_cloudwatch do
+      rsudo "service newrelic_aws_cloudwatch start"
+    end
+
+    desc "Restarts the newrelic_aws_cloudwatch"
+    task :restart, :roles => :newrelic_aws_cloudwatch do
+      stop
+      start
+    end
+
+  end
+end

--- a/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/monit-newrelic_aws_cloudwatch.conf
+++ b/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/monit-newrelic_aws_cloudwatch.conf
@@ -1,0 +1,9 @@
+<%
+  @path = '/etc/monit/monit.d/monit-newrelic_aws_cloudwatch.conf'
+%>
+
+check process newrelic_aws_cloudwatch with pidfile <%= rubber_env.newrelic_aws_cloudwatch_pid_file %>
+   group newrelic_aws_cloudwatch-<%= Rubber.env %>
+   start program = "/usr/bin/env service newrelic_aws_cloudwatch restart"
+   stop program = "/usr/bin/env service newrelic_aws_cloudwatch stop"
+   if 5 restarts within 5 cycles then timeout

--- a/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/newrelic_aws_cloudwatch-upstart.conf
+++ b/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/newrelic_aws_cloudwatch-upstart.conf
@@ -1,0 +1,27 @@
+<%
+  @path = "/etc/init/newrelic_aws_cloudwatch.conf"
+  @backup = false
+%>
+description "newrelic aws monitor"
+
+start on runlevel [2345]
+stop on runlevel [016]
+
+script
+  #todo something about the path spec
+  export PATH=<%= ENV['PATH'] %>
+  export RUBBER_ENV=<%= Rubber.env %>
+  export RAILS_ENV=<%= Rubber.env %>
+
+  cd <%= rubber_env.newrelic_aws_cloudwatch_home %>
+  bundle install #todo figure out necessary?
+  bundle exec ./bin/newrelic_aws
+end script
+
+post-start script
+  status newrelic_aws_cloudwatch | head -n1 | awk '{print $NF}' > <%= rubber_env.newrelic_aws_cloudwatch_pid_file %>
+end script
+
+post-stop script
+  rm -f <%= rubber_env.newrelic_aws_cloudwatch_pid_file %>
+end script

--- a/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/newrelic_plugin.yml
+++ b/templates/newrelic_aws_cloudwatch/config/rubber/role/newrelic_aws_cloudwatch/newrelic_plugin.yml
@@ -1,0 +1,50 @@
+<%
+  @path = "#{rubber_env.newrelic_aws_cloudwatch_home}/config/newrelic_plugin.yml"
+%>
+
+# Please make sure to update the license_key information with the
+# license key for your New Relic account.
+#
+newrelic:
+  #
+  # Update with your New Relic account license key:
+  #
+  license_key: '<%=rubber_env.newrelic_aws_cloudwatch_license_key %>'
+  #
+  # Set to '1' for verbose output, remove for normal output.
+  # All output goes to stdout/stderr.
+  #
+  # verbose: 1
+#
+# AWS configuration.
+#
+aws:
+  # Update with you AWS account keys:
+  access_key: '<%=rubber_env.newrelic_aws_cloudwatch_aws_key %>'
+  secret_key: '<%=rubber_env.newrelic_aws_cloudwatch_aws_secret %>'
+  # Specify AWS regions to query for metrics
+  # regions:
+  #   us-east-1
+#
+# Agent configuration.
+#
+agents:
+  #
+  # Uncomment an agent to enable it. Set 'overview' to true to
+  # enable its overview plugin (eg. EC2 Overview), displaying all
+  # metrics on a single dashboard (currently only available for EC2 & EBS).
+  #
+  ec2:
+    overview: true
+  ebs:
+    overview: true
+  # elb:
+  #   overview: false
+  # rds:
+  #   overview: false
+  # sqs:
+  #   overview: false
+  # sns:
+  #   overview: false
+  # ec:
+  #   overview: false

--- a/templates/newrelic_aws_cloudwatch/config/rubber/rubber-newrelic_aws_cloudwatch.yml
+++ b/templates/newrelic_aws_cloudwatch/config/rubber/rubber-newrelic_aws_cloudwatch.yml
@@ -1,0 +1,8 @@
+newrelic_aws_cloudwatch_home: '/usr/local/newrelic_aws_cloudwatch'
+newrelic_aws_cloudwatch_pid_file: '/var/run/newrelic_aws_cloudwatch.pid'
+
+newrelic_aws_cloudwatch_license_key: LICENSE_KEY
+newrelic_aws_cloudwatch_aws_key: AWS_KEY
+newrelic_aws_cloudwatch_aws_secret: AWS_SECRET
+
+

--- a/templates/newrelic_aws_cloudwatch/templates.yml
+++ b/templates/newrelic_aws_cloudwatch/templates.yml
@@ -1,0 +1,1 @@
+description: Newrelic AWS Cloudwatch Plugin


### PR DESCRIPTION
Add the newrelic AWS plugin agent which uses the CloudWatch API to gather statistics and send to newrelic.

Only question I have is if the bundle install is necessary within the upstart script. In RVM, I had trouble getting the bundled gems properly setup during bootstrap, so I also bundle installed during upstart. It seems to work now with ruby-build, but the bundle install doesnt hurt anything.  

Feel free to add your thoughts.
