### PR TITLE
squid process template for internal proxy

### DIFF
--- a/templates/squid/config/rubber/deploy-squid.rb
+++ b/templates/squid/config/rubber/deploy-squid.rb
@@ -1,0 +1,34 @@
+namespace :rubber do
+
+  namespace :squid do
+
+    rubber.allow_optional_tasks(self)
+
+    before "deploy:stop", "rubber:squid:stop"
+    after "deploy:start", "rubber:squid:start"
+    after "deploy:restart", "rubber:squid:reload"
+
+    desc "Stops the squid"
+    task :stop, :roles => :squid do
+      rsudo "service squid3 stop || true"
+    end
+
+    desc "Starts the squid"
+    task :start, :roles => :squid do
+      rsudo "service squid3 start"
+    end
+
+    desc "Restarts the squid"
+    task :restart, :roles => :squid do
+      stop
+      start
+    end
+
+    desc "Reload the squid"
+    task :reload, :roles => :squid do
+      rsudo "service squid3 reload"
+    end
+
+  end
+
+end

--- a/templates/squid/config/rubber/role/squid/crontab
+++ b/templates/squid/config/rubber/role/squid/crontab
@@ -1,0 +1,7 @@
+<%
+  @read_cmd = 'crontab -l'
+  @write_cmd = 'crontab -'
+  @additive = ['# start-squid-crontab', '# end-squid-crontab']
+%>
+
+0 0 * * * /usr/sbin/squid3 -k rotate

--- a/templates/squid/config/rubber/role/squid/monit-squid.conf
+++ b/templates/squid/config/rubber/role/squid/monit-squid.conf
@@ -1,0 +1,9 @@
+<%
+  @path = '/etc/monit/monit.d/monit-squid.conf'
+%>
+
+check process squid3 with pidfile /run/squid3.pid
+   group squid-<%= Rubber.env %>
+   start program = "/etc/init.d/squid3 start"
+   stop  program = "/etc/init.d/squid3 stop"
+   if 5 restarts within 5 cycles then timeout

--- a/templates/squid/config/rubber/role/squid/squid.conf
+++ b/templates/squid/config/rubber/role/squid/squid.conf
@@ -1,0 +1,60 @@
+<%
+  @path = '/etc/squid3/squid.conf'
+%>
+#ip setup
+http_port <%= rubber_env.squid_port %>
+
+## host definitions
+##squid 3.1,  all predefined
+##squid 3.2+, manager, localhost, and to_localhost are predefined.
+acl localhost src 127.0.0.1/32 ::1
+acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+acl private_nets src 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+
+acl mynetworks src 127.0.0.1/32 ::1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16
+## proxy server client access
+http_access deny !mynetworks
+
+## timeouts
+forward_timeout 30 seconds
+connect_timeout 30 seconds
+read_timeout 30 seconds
+request_timeout 30 seconds
+persistent_request_timeout 1 minute
+client_lifetime 20 hours
+
+## disable caching
+cache deny all
+#cache_dir null /tmp
+
+## manager
+acl manager proto cache_object
+http_access allow manager localhost
+http_access deny manager
+
+## disable multicast icp
+icp_port 0
+icp_access deny all
+
+## disable ident lookups
+ident_lookup_access deny all
+
+## ports allowed
+acl Safe_ports port 80 443
+http_access deny !Safe_ports
+
+## ssl ports/method allowed
+acl SSL_ports port 443
+acl CONNECT method CONNECT
+http_access deny CONNECT !SSL_ports
+
+## protocols allowed
+acl Safe_proto proto HTTP SSL
+http_access deny !Safe_proto
+
+## methods allowed
+acl Safe_method method CONNECT GET HEAD POST
+http_access deny !Safe_method
+
+## allow replies to client requests
+http_reply_access allow all

--- a/templates/squid/config/rubber/rubber-squid.yml
+++ b/templates/squid/config/rubber/rubber-squid.yml
@@ -1,0 +1,5 @@
+squid_port: 3131
+
+roles:
+  squid:
+    packages: [squid3]

--- a/templates/squid/templates.yml
+++ b/templates/squid/templates.yml
@@ -1,0 +1,1 @@
+description: Squid Server Template


### PR DESCRIPTION
This is a useful template for VPCs or other clusters which need a small set of static IPs exposed to the outside for requests, for example in whitelisted API cases.

The default configuration of this proxy is to not cache, just proxy requests.  The squid whitelist of allowed IPs assumes the other instances will reach it on typical private IP address blocks.
