### PR TITLE
Add postgresql-locale variable and pass it to initdb

### DIFF
--- a/templates/postgresql/config/rubber/deploy-postgresql.rb
+++ b/templates/postgresql/config/rubber/deploy-postgresql.rb
@@ -46,7 +46,7 @@ namespace :rubber do
           exists = capture("echo $(ls #{env.postgresql_data_dir}/ 2> /dev/null)")
           if exists.strip.size == 0
             common_bootstrap
-            sudo "/usr/lib/postgresql/#{rubber_env.postgresql_ver}/bin/initdb -D #{rubber_env.postgresql_data_dir}", :as => 'postgres'
+            sudo "/usr/lib/postgresql/#{rubber_env.postgresql_ver}/bin/initdb --locale=#{rubber_env.postgresql_locale} -D #{rubber_env.postgresql_data_dir}", :as => 'postgres'
             sudo "#{rubber_env.postgresql_ctl} start"
             sleep 5
 

--- a/templates/postgresql/config/rubber/rubber-postgresql.yml
+++ b/templates/postgresql/config/rubber/rubber-postgresql.yml
@@ -24,6 +24,10 @@ postgresql_data_dir: "/mnt/postgresql/#{postgresql_ver}/data"
 postgresql_archive_dir: "/mnt/postgresql/#{postgresql_ver}/archive"
 postgresql_pid_file: "/var/run/postgresql/#{postgresql_ver}-main.pid"
 postgresql_ctl: "/usr/bin/env service postgresql"
+# Force locale to utf8 when installing postgres
+# to match 'unicode' encoding specified in database.yml
+# This needs to be a locale listed in the bare instance's `locale -a`
+postgresql_locale: "en_US.UTF-8"
 
 # Capistrano needs db:primary role for migrate to work,
 # so we might as well just make consistent across the board


### PR DESCRIPTION
On Vagrant, rails can't create a postgresql database because postgres gets installed with the Latin1 encoding and rails wants to create db's with unicode encoding. I added a flag to pass the locale into the initdb command,
and added a configuration option in `rubber-postgresql.yml` to make it easy to change the locale if desired. 
Tested with an install on vagrant (hashicorp/precise64 and hashicorp/precise32), and EC2 (ubuntu 12.04.4).
The default, `en_US.UTF-8`, ought to be suitable for any rails app on any US-based platform.
