### PR TITLE
Add Nginx parameter required by DigitalOcean droplets.

### DIFF
--- a/templates/discourse/config/rubber/role/nginx/nginx.conf
+++ b/templates/discourse/config/rubber/role/nginx/nginx.conf
@@ -21,6 +21,7 @@ http
   sendfile          on;
   tcp_nopush        on;
   tcp_nodelay       off;
+  types_hash_max_size 2048;
 
   gzip              on;
   gzip_http_version 1.0;


### PR DESCRIPTION
Fix for #446.
