### PR TITLE
Adding missing closing bracket. Fixes #511

### DIFF
--- a/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
+++ b/templates/passenger_nginx/config/rubber/rubber-passenger_nginx.yml
@@ -14,4 +14,4 @@ use_ssl_key: false
 
 roles:
   passenger_nginx:
-    packages: [libcurl4-openssl-dev, libpcre3-dev, nginx-extras, [passenger, "#{passenger_version}"]
+    packages: [libcurl4-openssl-dev, libpcre3-dev, nginx-extras, [passenger, "#{passenger_version}"]]


### PR DESCRIPTION
This fixes a bug where rubber cannot vulcanize with the passenger_nginx package.
