### PR TITLE
Surround postgresql database name with quotes to avoid syntax error when using dash

### DIFF
--- a/templates/postgresql/config/rubber/deploy-postgresql.rb
+++ b/templates/postgresql/config/rubber/deploy-postgresql.rb
@@ -1,7 +1,7 @@
 namespace :rubber do
-  
+
   namespace :postgresql do
-    
+
     rubber.allow_optional_tasks(self)
 
     before "rubber:install_packages", "rubber:postgresql:setup_apt_sources"
@@ -12,7 +12,7 @@ namespace :rubber do
         wget --quiet -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -
       ENDSCRIPT
     end
-    
+
     after "rubber:create", "rubber:postgresql:validate_db_roles"
 
     task :validate_db_roles do
@@ -25,16 +25,16 @@ namespace :rubber do
     end
 
     after "rubber:bootstrap", "rubber:postgresql:bootstrap"
-    
+
     # Bootstrap the production database config.  Db bootstrap is special - the
     # user could be requiring the rails env inside some of their config
     # templates, which creates a catch 22 situation with the db, so we try and
     # bootstrap the db separate from the rest of the config
     task :bootstrap, :roles => [:postgresql_master, :postgresql_slave] do
-      
+
       # Conditionally bootstrap for each node/role only if that node has not
       # been bootstrapped for that role before
-      master_instances = rubber_instances.for_role("postgresql_master") & rubber_instances.filtered  
+      master_instances = rubber_instances.for_role("postgresql_master") & rubber_instances.filtered
       master_instances.each do |ic|
         task_name = "_bootstrap_postgresql_master_#{ic.full_name}".to_sym()
         task task_name, :hosts => ic.full_name do
@@ -55,7 +55,7 @@ namespace :rubber do
             rubber.sudo_script "create_master_db", <<-ENDSCRIPT
               sudo -i -u postgres psql -c "#{create_user_cmd}"
               sudo -i -u postgres psql -c "#{create_replication_user_cmd}"
-              sudo -i -u postgres psql -c "CREATE DATABASE #{env.db_name} WITH OWNER #{env.db_user}"
+              sudo -i -u postgres psql -c "CREATE DATABASE \"#{env.db_name}\" WITH OWNER #{env.db_user}"
             ENDSCRIPT
           end
         end
@@ -91,7 +91,7 @@ namespace :rubber do
     def common_bootstrap
       # postgresql package install starts postgresql, so stop it
       rsudo "#{rubber_env.postgresql_ctl} stop" rescue nil
-      
+
       # After everything installed on machines, we need the source tree
       # on hosts in order to run rubber:config for bootstrapping the db
       rubber.update_code_for_bootstrap
@@ -114,15 +114,15 @@ namespace :rubber do
     task :promote_slave do
       master_alias = get_env('MASTER', "Master alias (e.g. db01)", true)
       slave_alias = get_env('SLAVE', "Slave alias (e.g. db02)", true)
-      
+
       # remove the master instance so rubber doesn't try to deploy to it
       # Stays running so needs to be manually deleted
       master_instance = rubber_instances.remove(master_alias)
       fatal "Master Instance does not exist: #{master_alias}" unless master_instance
-      
+
       slave_instance = rubber_instances[slave_alias]
       fatal "Slave Instance does not exist: #{slave_alias}" unless slave_instance
-      
+
       # remove all db roles from slave
       slave_instance.roles.delete_if {|ir| ir.name =~ /db|postgresql/ }
 
@@ -130,9 +130,9 @@ namespace :rubber do
       new_roles = [Rubber::Configuration::RoleItem.parse("postgresql_master")]
       new_roles = Rubber::Configuration::RoleItem.expand_role_dependencies(new_roles, get_role_dependencies)
       slave_instance.roles = (slave_instance.roles + new_roles).uniq
-      
+
       rubber_instances.save()
-      
+
       begin
         Timeout::timeout(10) do
           logger.info "Stopping server on original master #{master_alias}"
@@ -142,10 +142,10 @@ namespace :rubber do
       rescue StandardError
         logger.info "Failed to connect to original master, promoting slave anyway"
       end
-      
+
       logger.info "Triggering slave promotion on new master #{slave_alias}"
       rsudo "touch #{rubber_env.postgresql_data_dir}/trigger_file", :hosts => slave_instance.full_name
-      
+
       logger.info "The master instance has been removed from instances, but remains running:"
       logger.info "#{master_alias}, #{master_instance.instance_id}, #{master_instance.external_ip}"
       logger.info ''
@@ -161,14 +161,14 @@ namespace :rubber do
     task :start, :roles => [:postgresql_master, :postgresql_slave] do
       rsudo "#{rubber_env.postgresql_ctl} start"
     end
-    
+
     desc <<-DESC
       Stops the postgresql daemons
     DESC
     task :stop, :roles => [:postgresql_master, :postgresql_slave] do
       rsudo "#{rubber_env.postgresql_ctl} stop || true"
     end
-  
+
     desc <<-DESC
       Restarts the postgresql daemons
     DESC


### PR DESCRIPTION
Trying to deploy a new instance with this-kind-of-name, it fails on the database creation.
Looking at /tmp/create_master_db I noticed the instruction wasn't quoted.
