### PR TITLE
Fix crash due to spot instance race condition

### DIFF
--- a/lib/rubber/recipes/rubber/instances.rb
+++ b/lib/rubber/recipes/rubber/instances.rb
@@ -292,7 +292,7 @@ namespace :rubber do
         max_wait_time -= 2
 
         request = cloud.describe_spot_instance_requests(request_id).first
-        instance_id = request[:instance_id]
+        instance_id = request ? request[:instance_id] : nil
 
         if max_wait_time < 0 && instance_id.nil?
           cloud.destroy_spot_instance_request(request[:id])


### PR DESCRIPTION
Rubber crashed on me creating spot instances. It seems to be a race condition in lib/rubber/recipes/rubber/instances.rb 
Here is the error:
/Users/jimsalem/.rvm/gems/ruby-2.1.2@master/bundler/gems/rubber-6b301f4d3fda/lib/rubber/recipes/rubber/instances.rb:306:in `create_instance': undefined method`[]' for nil:NilClass (NoMethodError)
Note that line 306 is line 295 in the current master.

This one line change fixes the error.
