### PR TITLE
Add template for NodeJS

### DIFF
--- a/templates/nodejs/config/rubber/deploy-nodejs.rb
+++ b/templates/nodejs/config/rubber/deploy-nodejs.rb
@@ -1,0 +1,60 @@
+namespace :rubber do
+
+  namespace :nodejs do
+
+    rubber.allow_optional_tasks(self)
+
+    before "rubber:install_packages", "rubber:nodejs:setup_apt_sources"
+
+    desc "add nodejs repo"
+    task :setup_apt_sources, roles: :nodejs do
+      rsudo "apt-get install python-software-properties"
+      rsudo "add-apt-repository ppa:chris-lea/node.js -y"
+      rsudo "apt-get update"
+    end
+
+    after "rubber:bootstrap", "rubber:nodejs:update_nodejs_version"
+    task :update_nodejs_version, roles: :nodejs do
+      rsudo "npm cache clean -f"
+      rsudo "npm install -g n"
+      rsudo "sudo n 0.11.10"
+    end
+
+    before 'deploy:stop', 'rubber:nodejs:stop'
+    after 'deploy:start', 'rubber:nodejs:start'
+    after 'deploy:restart', 'rubber:nodejs:restart'
+
+    before 'rubber:nodejs:start', 'rubber:nodejs:install'
+    before 'rubber:nodejs:restart', 'rubber:nodejs:install'
+
+    desc 'Installs npm dependencies for nodejs'
+    task :install, roles: :nodejs do
+      rsudo "cd #{current_path}/#{rubber_env.nodejs.app_dir}; npm install"
+    end
+    
+    desc 'Starts the nodejs daemon'
+    task :start, roles: :nodejs do
+      rsudo "service nodejs start --force"
+    end
+
+    desc 'Stops the nodejs daemon'
+    task :stop, roles: :nodejs do
+      rsudo "service nodejs stop --force"
+    end
+
+    desc 'Hard kill the nodejs daemon, manually deleting pid and socket'
+    task :kill, roles: :nodejs do
+      rsudo "rm -r -f #{rubber_env.nodejs.pid_dir}/#{rubber_env.nodejs.pid_file} && pkill -9 -f '/bin/node '"
+    end
+
+    desc 'Restarts the nodejs daemon'
+    task :restart, roles: :nodejs do
+      rsudo "service nodejs restart --force"
+    end
+
+    desc 'Restarts the nodejs daemon'
+    task :status, roles: :nodejs do
+      rsudo "service nodejs status"
+    end
+  end
+end

--- a/templates/nodejs/config/rubber/role/nodejs/config.js
+++ b/templates/nodejs/config/rubber/role/nodejs/config.js
@@ -1,0 +1,11 @@
+<%
+  current_path = "/mnt/#{rubber_env.app_name}-#{Rubber.env}/current"
+  cwd_path = "#{current_path}/#{rubber_env.nodejs.app_dir}"
+  @path = "#{cwd_path}/#{rubber_env.nodejs.config_file}"
+%>
+
+config = {
+  // my config goes here
+};
+
+module.exports = config

--- a/templates/nodejs/config/rubber/role/nodejs/monit-nodejs.conf
+++ b/templates/nodejs/config/rubber/role/nodejs/monit-nodejs.conf
@@ -1,0 +1,12 @@
+<%
+  @path = "/etc/monit/monit.d/monit-nodejs.conf"
+  pid_path = "#{rubber_env.nodejs.pid_dir}/#{rubber_env.nodejs.pid_file}"
+%>
+
+check process nodejs with pidfile <%= pid_path %>
+  start program = "/usr/bin/env service nodejs start --force"
+  stop program  = "/usr/bin/env service nodejs stop --force"
+  if failed port <%= rubber_env.nodejs.port %> protocol HTTP
+    request /
+    with timeout 10 seconds
+    then restart

--- a/templates/nodejs/config/rubber/role/nodejs/nodejs-init.d
+++ b/templates/nodejs/config/rubber/role/nodejs/nodejs-init.d
@@ -1,0 +1,158 @@
+<%
+  @path = "/etc/init.d/nodejs"
+  @perms = 0755
+  current_path = "/mnt/#{rubber_env.app_name}-#{Rubber.env}/current"
+  log_dir = "/mnt/#{rubber_env.app_name}-#{Rubber.env}/shared/log"
+  app_dir = "#{current_path}/#{rubber_env.nodejs.app_dir}"
+%>
+
+#!/bin/sh
+
+# Adapted from https://github.com/chovy/node-startup
+
+NODE_ENV="production"
+PORT="<%= rubber_env.nodejs.port %>"
+APP_DIR="<%= app_dir %>"
+NODE_APP="<%= rubber_env.nodejs.app_file %>"
+CONFIG_DIR="$APP_DIR"
+PID_DIR="<%= rubber_env.nodejs.pid_dir %>"
+PID_FILE="$PID_DIR/<%= rubber_env.nodejs.pid_file %>"
+LOG_DIR="<%= log_dir %>"
+LOG_FILE="$LOG_DIR/nodejs.log"
+NODE_EXEC=$(which node)
+
+USAGE="Usage: $0 {start|stop|restart|status} [--force]"
+FORCE_OP=false
+
+pid_file_exists() {
+  [ -f "$PID_FILE" ]
+}
+
+get_pid() {
+  echo "$(cat "$PID_FILE")"
+}
+
+is_running() {
+  PID=$(get_pid)
+  ! [ -z "$(ps ef | awk '{print $1}' | grep "^$PID$")" ]
+}
+
+start_it() {
+  mkdir -p "$PID_DIR"
+  mkdir -p "$LOG_DIR"
+
+  echo "Starting node app ..."
+
+  PORT="$PORT" NODE_ENV="$NODE_ENV" NODE_CONFIG_DIR="$CONFIG_DIR" $NODE_EXEC "$APP_DIR/$NODE_APP"  1>"$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+  echo "Node app started with pid $!"
+}
+
+stop_process() {
+  PID=$(get_pid)
+  echo "Killing process $PID"
+  kill $PID
+}
+
+remove_pid_file() {
+  echo "Removing pid file"
+  rm -f "$PID_FILE"
+}
+
+start_app() {
+  if pid_file_exists
+  then
+    if is_running
+    then
+      PID=$(get_pid)
+      echo "Node app already running with pid $PID"
+      exit 1
+    else
+      echo "Node app stopped, but pid file exists"
+      if [ $FORCE_OP = true ]
+      then
+        echo "Forcing start anyways ..."
+        remove_pid_file
+        start_it
+      fi
+    fi
+  else
+    start_it
+  fi
+}
+
+stop_app() {
+  if pid_file_exists
+  then
+    if is_running
+    then
+      echo "Stopping node app ..."
+      stop_process
+      remove_pid_file
+      echo "Node app stopped"
+    else
+      echo "Node app already stopped, but pid file exists"
+      if [ $FORCE_OP = true ]
+      then
+        echo "Forcing stop anyways ..."
+        remove_pid_file
+        echo "Node app stopped"
+      fi
+    fi
+  else
+    echo "Node app already stopped, pid file does not exist"
+  fi
+}
+
+status_app() {
+  if pid_file_exists
+  then
+    if is_running
+    then
+      PID=$(get_pid)
+      echo "Node app running with pid $PID"
+    else
+      echo "Node app stopped, but pid file exists"
+    fi
+  else
+    echo "Node app stopped"
+  fi
+}
+
+case "$2" in
+  --force)
+    FORCE_OP=true
+  ;;
+
+  "")
+  ;;
+
+  *)
+    echo $USAGE
+    exit 1
+  ;;
+esac
+
+case "$1" in
+  start)
+    start_app
+  ;;
+
+  stop)
+    stop_app
+  ;;
+
+  restart)
+    stop_app
+    start_app
+  ;;
+
+  status)
+    status_app
+  ;;
+
+  *)
+    echo $USAGE
+    exit 1
+  ;;
+esac

--- a/templates/nodejs/config/rubber/rubber-nodejs.yml
+++ b/templates/nodejs/config/rubber/rubber-nodejs.yml
@@ -1,0 +1,20 @@
+roles:
+  nodejs:
+    packages: [nodejs]
+
+nodejs:
+  app_dir:  'my/nodejs/dir'
+  app_file: 'app.js'
+  config_file: 'config.js'
+  pid_dir:  '/var/run'
+  pid_file: 'nodejs.pid'
+  port: 4300
+
+security_groups:
+  nodejs:
+    description: "To open up web port for nodejs server on nodejs role"
+    rules:
+      - protocol: tcp
+        from_port: "#{nodejs.port}"
+        to_port: "#{nodejs.port}"
+        source_ips: [0.0.0.0/0]

--- a/templates/nodejs/templates.yml
+++ b/templates/nodejs/templates.yml
@@ -1,0 +1,1 @@
+description: The nodejs server module


### PR DESCRIPTION
NodeJS is useful to make small standalone apps. My app uses it for a realtime event pusher via websockets. This PR includes the template to deploy a Node app including monit.

You'll have to create a node app in a sub-folder of your Rails app (example not included in this code), and specify the dir in `rubber_env.node.app_dir`

The init.d script is adapted from https://github.com/chovy/node-startup.
