### PR TITLE
BUG FIX: broken method interface Aws#create_spot_instance_request

### DIFF
--- a/lib/rubber/cloud/aws.rb
+++ b/lib/rubber/cloud/aws.rb
@@ -216,13 +216,13 @@ module Rubber
         return zones
       end
 
-      def create_spot_instance_request(spot_price, ami, ami_type, security_groups, availability_zone)
-        response = compute_provider.spot_requests.create(:price => spot_price,
+      def create_spot_instance_request(spot_price, ami, ami_type, security_groups, availability_zone, fog_options={})
+        response = compute_provider.spot_requests.create({:price => spot_price,
                                                           :image_id => ami,
                                                           :flavor_id => ami_type,
                                                           :groups => security_groups,
                                                           :availability_zone => availability_zone,
-                                                          :key_name => env.key_name)
+                                                          :key_name => env.key_name}.merge(Rubber::Util.symbolize_keys(fog_options)))
         request_id = response.id
         return request_id
       end


### PR DESCRIPTION
Seems like version v2.15.0 broke the method interface for `Aws#create_spot_instance_request`. I've fixed it here, please take a look and confirm this is correct.
