### PR TITLE
Nginx template: set UTF-8 charset and do not echo server version

### DIFF
--- a/templates/nginx/config/rubber/role/nginx/nginx.conf
+++ b/templates/nginx/config/rubber/role/nginx/nginx.conf
@@ -21,6 +21,8 @@ http
   sendfile          on;
   tcp_nopush        on;
   tcp_nodelay       off;
+  server_tokens     off;
+  charset           utf-8;
 
   gzip              on;
   gzip_http_version 1.0;


### PR DESCRIPTION
For security purposes, it's better to hide the nginx version in the web response by default. Also it's good to set UTF-8 charset.
