### PR TITLE
Make sync_security_groups method a bit clearer, add Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ RubyOnRails applications to Amazon's Elastic Compute Cloud (EC2).
 See the documentation in the github wiki for more details:
 http://github.com/rubber/rubber/wiki
 
-[![Build Status](https://secure.travis-ci.org/rubber/rubber.png)](http://travis-ci.org/rubber/rubber)
+[![Build Status](https://secure.travis-ci.org/rubber/rubber.png)](http://travis-ci.org/rubber/rubber)[![Code Climate](https://codeclimate.com/github/rubber/rubber/badges/gpa.svg)](https://codeclimate.com/github/rubber/rubber)


### PR DESCRIPTION
When poking around in Code Climate for OSS repos to contribute to, I found rubber. Poking around, I found some methods difficult to understand - I made a small change to clarify one method by pulling some of its work into private methods. I also added the Code Climate badge to your README - it surfaced this complexity issue for me and could help in the future!