### PR TITLE
Replacing defunct passenger_set_cgi_param with passenger_env_var

### DIFF
--- a/templates/passenger/config/rubber/rubber-passenger.yml
+++ b/templates/passenger/config/rubber/rubber-passenger.yml
@@ -1,4 +1,4 @@
-passenger_version: '1:5.0.6-1~`lsb_release -sc`1'
+passenger_version: '1:5.0.7-1~`lsb_release -sc`1'
 passenger_ruby: "#{ruby_path}/bin/ruby"
 passenger_listen_port: 7000
 passenger_listen_ssl_port: 7001

--- a/templates/passenger_nginx/config/rubber/role/passenger_nginx/application.conf
+++ b/templates/passenger_nginx/config/rubber/role/passenger_nginx/application.conf
@@ -4,7 +4,7 @@
 
 server_name  <%= [ rubber_env.domain, rubber_env.web_aliases ].flatten.compact.join(" ") %>;
 passenger_enabled on;
-passenger_set_cgi_param HTTP_X_QUEUE_START "t=${msec}000";
+passenger_env_var HTTP_X_QUEUE_START "t=${msec}000";
 
 root <%= Rubber.root + "/public" %>;
 


### PR DESCRIPTION
As shown in the Passenger 5 beta 1 [changelog](http://old.blog.phusion.nl/2014/11/25/introducing-phusion-passenger-5-beta-1-codename-raptor), `passenger_set_cgi_param` has been replaced by `passenger_env_var`.