### PR TITLE
Add rubber configuration instance check.

### DIFF
--- a/lib/rubber/configuration.rb
+++ b/lib/rubber/configuration.rb
@@ -26,7 +26,7 @@ module Rubber
       raise "This convenience method needs Rubber.env to be set" unless Rubber.env
       cfg = Rubber::Configuration.get_configuration(Rubber.env)
       host = cfg.environment.current_host
-      roles = cfg.instance[host] ? cfg.instance[host].role_names : nil
+      roles = cfg.instance and cfg.instance[host] ? cfg.instance[host].role_names : nil
       cfg.environment.bind(roles, host)
     end
 


### PR DESCRIPTION
We have an empty instance-production.yml in local folder and saved instance in s3, the rubber configuration will raise an error.
rubber-3.1.0/lib/rubber/configuration.rb:31:in `rubber_env': undefined method`[]' for nil:NilClass (NoMethodError)
