### PR TITLE
Upgrade elasticsearch template to 1.7.0, decouple from graylog

### DIFF
--- a/templates/elasticsearch/config/rubber/role/elasticsearch/elasticsearch.yml
+++ b/templates/elasticsearch/config/rubber/role/elasticsearch/elasticsearch.yml
@@ -1,7 +1,7 @@
 <%
   @path = '/etc/elasticsearch/elasticsearch.yml'
 -%>
-##################### ElasticSearch Configuration Example #####################
+##################### Elasticsearch Configuration Example #####################
 
 # This file contains an overview of various configuration settings,
 # targeted at operations staff. Application developers should
@@ -10,7 +10,7 @@
 # The installation procedure is covered at
 # <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup.html>.
 #
-# ElasticSearch comes with reasonable defaults for most settings,
+# Elasticsearch comes with reasonable defaults for most settings,
 # so you can try it out without bothering with configuration.
 #
 # Most of the time, these defaults are just fine for running a production
@@ -21,7 +21,7 @@
 # Any element in the configuration can be replaced with environment variables
 # by placing them in ${...} notation. For example:
 #
-# node.rack: ${RACK_ENV_VAR}
+#node.rack: ${RACK_ENV_VAR}
 
 # For information on supported formats and syntax for the config file, see
 # <http://elasticsearch.org/guide/en/elasticsearch/reference/current/setup-configuration.html>
@@ -32,7 +32,7 @@
 # Cluster name identifies your cluster for auto-discovery. If you're running
 # multiple clusters on the same network, make sure you're using unique names.
 #
-cluster.name: <%= rubber_env.graylog_elasticsearch_index %>
+cluster.name: <%= rubber_env.elasticsearch_cluster_name %>
 
 
 #################################### Node #####################################
@@ -40,54 +40,56 @@ cluster.name: <%= rubber_env.graylog_elasticsearch_index %>
 # Node names are generated dynamically on startup, so you're relieved
 # from configuring them manually. You can tie this node to a specific name:
 #
-# node.name: "Franz Kafka"
+#node.name: "Franz Kafka"
 
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.
 #
 # Allow this node to be eligible as a master node (enabled by default):
 #
-# node.master: true
+#node.master: true
 #
 # Allow this node to store data (enabled by default):
 #
-# node.data: true
+#node.data: true
 
 # You can exploit these settings to design advanced cluster topologies.
 #
 # 1. You want this node to never become a master node, only to hold data.
 #    This will be the "workhorse" of your cluster.
 #
-# node.master: false
-# node.data: true
+#node.master: false
+#node.data: true
 #
 # 2. You want this node to only serve as a master: to not store any data and
 #    to have free resources. This will be the "coordinator" of your cluster.
 #
-# node.master: true
-# node.data: false
+#node.master: true
+#node.data: false
 #
 # 3. You want this node to be neither master nor data node, but
 #    to act as a "search load balancer" (fetching data from nodes,
 #    aggregating results, etc.)
 #
-# node.master: false
-# node.data: false
+#node.master: false
+#node.data: false
 
 # Use the Cluster Health API [http://localhost:9200/_cluster/health], the
-# Node Info API [http://localhost:9200/_cluster/nodes] or GUI tools
-# such as <http://github.com/lukas-vlcek/bigdesk> and
+# Node Info API [http://localhost:9200/_nodes] or GUI tools
+# such as <http://www.elasticsearch.org/overview/marvel/>,
+# <http://github.com/karmi/elasticsearch-paramedic>,
+# <http://github.com/lukas-vlcek/bigdesk> and
 # <http://mobz.github.com/elasticsearch-head> to inspect the cluster state.
 
 # A node can have generic attributes associated with it, which can later be used
 # for customized shard allocation filtering, or allocation awareness. An attribute
 # is a simple key value pair, similar to node.key: value, here is an example:
 #
-# node.rack: rack314
+#node.rack: rack314
 
 # By default, multiple nodes are allowed to start from the same installation location
 # to disable it, set the following:
-# node.max_local_storage_nodes: 1
+#node.max_local_storage_nodes: 1
 
 
 #################################### Index ####################################
@@ -105,17 +107,17 @@ cluster.name: <%= rubber_env.graylog_elasticsearch_index %>
 
 # Set the number of shards (splits) of an index (5 by default):
 #
-# index.number_of_shards: 5
+#index.number_of_shards: 5
 
 # Set the number of replicas (additional copies) of an index (1 by default):
 #
-# index.number_of_replicas: 1
+#index.number_of_replicas: 1
 
 # Note, that for development on a local machine, with small indices, it usually
 # makes sense to "disable" the distributed features:
 #
-# index.number_of_shards: 1
-# index.number_of_replicas: 0
+#index.number_of_shards: 1
+#index.number_of_replicas: 0
 
 # These settings directly affect the performance of index and search operations
 # in your cluster. Assuming you have enough machines to hold shards and
@@ -131,7 +133,7 @@ cluster.name: <%= rubber_env.graylog_elasticsearch_index %>
 # The "number_of_replicas" can be increased or decreased anytime,
 # by using the Index Update Settings API.
 #
-# ElasticSearch takes care about load balancing, relocating, gathering the
+# Elasticsearch takes care about load balancing, relocating, gathering the
 # results from nodes, etc. Experiment with different settings to fine-tune
 # your setup.
 
@@ -143,7 +145,7 @@ cluster.name: <%= rubber_env.graylog_elasticsearch_index %>
 
 # Path to directory containing configuration (this file and logging.yml):
 #
-# path.conf: /path/to/conf
+#path.conf: /path/to/conf
 
 # Path to directory where to store index data allocated for this node.
 #
@@ -153,7 +155,7 @@ path.data: <%= rubber_env.elasticsearch_data_dir %>
 # the locations (a la RAID 0) on a file level, favouring locations with most free
 # space on creation. For example:
 #
-# path.data: /path/to/data1,/path/to/data2
+#path.data: /path/to/data1,/path/to/data2
 
 # Path to temporary files:
 #
@@ -165,60 +167,60 @@ path.logs: <%= rubber_env.elasticsearch_log_dir %>
 
 # Path to where plugins are installed:
 #
-# path.plugins: /path/to/plugins
+#path.plugins: /path/to/plugins
 
 
 #################################### Plugin ###################################
 
 # If a plugin listed here is not installed for current node, the node will not start.
 #
-# plugin.mandatory: mapper-attachments,lang-groovy
+#plugin.mandatory: mapper-attachments,lang-groovy
 
 
 ################################### Memory ####################################
 
-# ElasticSearch performs poorly when JVM starts swapping: you should ensure that
+# Elasticsearch performs poorly when JVM starts swapping: you should ensure that
 # it _never_ swaps.
 #
 # Set this property to true to lock the memory:
 #
-# bootstrap.mlockall: true
+#bootstrap.mlockall: true
 
 # Make sure that the ES_MIN_MEM and ES_MAX_MEM environment variables are set
 # to the same value, and that the machine has enough memory to allocate
-# for ElasticSearch, leaving enough memory for the operating system itself.
+# for Elasticsearch, leaving enough memory for the operating system itself.
 #
-# You should also make sure that the ElasticSearch process is allowed to lock
+# You should also make sure that the Elasticsearch process is allowed to lock
 # the memory, eg. by using `ulimit -l unlimited`.
 
 
 ############################## Network And HTTP ###############################
 
-# ElasticSearch, by default, binds itself to the 0.0.0.0 address, and listens
+# Elasticsearch, by default, binds itself to the 0.0.0.0 address, and listens
 # on port [9200-9300] for HTTP traffic and on port [9300-9400] for node-to-node
 # communication. (the range means that if the port is busy, it will automatically
 # try the next port).
 
 # Set the bind address specifically (IPv4 or IPv6):
 #
-# network.bind_host: 192.168.0.1
+#network.bind_host: 192.168.0.1
 
 # Set the address other nodes will use to communicate with this node. If not
 # set, it is automatically derived. It must point to an actual IP address.
 #
-# network.publish_host: 192.168.0.1
+#network.publish_host: 192.168.0.1
 
 # Set both 'bind_host' and 'publish_host':
 #
-# network.host: 192.168.0.1
+#network.host: 192.168.0.1
 
 # Set a custom port for the node to node communication (9300 by default):
 #
-# transport.tcp.port: 9300
+#transport.tcp.port: 9300
 
 # Enable compression for all communication between nodes (disabled by default):
 #
-# transport.tcp.compress: true
+#transport.tcp.compress: true
 
 # Set a custom port to listen for HTTP traffic:
 #
@@ -226,11 +228,11 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 
 # Set a custom allowed content length:
 #
-# http.max_content_length: 100mb
+#http.max_content_length: 100mb
 
 # Disable HTTP completely:
 #
-# http.enabled: false
+#http.enabled: false
 
 
 ################################### Gateway ###################################
@@ -245,7 +247,7 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 
 # The default gateway type is the "local" gateway (recommended):
 #
-# gateway.type: local
+#gateway.type: local
 
 # Settings below control how and when to start the initial recovery process on
 # a full cluster restart (to reuse as much local data as possible when using shared
@@ -253,18 +255,18 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 
 # Allow recovery process after N nodes in a cluster are up:
 #
-# gateway.recover_after_nodes: 1
+#gateway.recover_after_nodes: 1
 
 # Set the timeout to initiate the recovery process, once the N nodes
 # from previous setting are up (accepts time value):
 #
-# gateway.recover_after_time: 5m
+#gateway.recover_after_time: 5m
 
 # Set how many nodes are expected in this cluster. Once these N nodes
 # are up (and recover_after_nodes is met), begin recovery process immediately
 # (without waiting for recover_after_time to expire):
 #
-# gateway.expected_nodes: 2
+#gateway.expected_nodes: 2
 
 
 ############################# Recovery Throttling #############################
@@ -277,20 +279,20 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 #
 # 1. During the initial recovery
 #
-# cluster.routing.allocation.node_initial_primaries_recoveries: 4
+#cluster.routing.allocation.node_initial_primaries_recoveries: 4
 #
 # 2. During adding/removing nodes, rebalancing, etc
 #
-# cluster.routing.allocation.node_concurrent_recoveries: 2
+#cluster.routing.allocation.node_concurrent_recoveries: 2
 
 # Set to throttle throughput when recovering (eg. 100mb, by default 20mb):
 #
-# indices.recovery.max_bytes_per_sec: 20mb
+#indices.recovery.max_bytes_per_sec: 20mb
 
 # Set to limit the number of open concurrent streams when
 # recovering a shard from a peer:
 #
-# indices.recovery.concurrent_streams: 5
+#indices.recovery.concurrent_streams: 5
 
 
 ################################## Discovery ##################################
@@ -299,16 +301,16 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 # and master node is elected. Multicast discovery is the default.
 
 # Set to ensure a node sees N other master eligible nodes to be considered
-# operational within the cluster. Its recommended to set it to a higher value
-# than 1 when running more than 2 nodes in the cluster.
+# operational within the cluster. This should be set to a quorum/majority of 
+# the master-eligible nodes in the cluster.
 #
-# discovery.zen.minimum_master_nodes: 1
+#discovery.zen.minimum_master_nodes: 1
 
 # Set the time to wait for ping responses from other nodes when discovering.
 # Set this option to a higher value on a slow or congested network
 # to minimize discovery failures:
 #
-# discovery.zen.ping.timeout: 3s
+#discovery.zen.ping.timeout: 3s
 
 # For more information, see
 # <http://elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html>
@@ -319,12 +321,12 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 #
 # 1. Disable multicast discovery (enabled by default):
 #
-# discovery.zen.ping.multicast.enabled: false
+#discovery.zen.ping.multicast.enabled: false
 #
 # 2. Configure an initial list of master nodes in the cluster
 #    to perform discovery when new nodes (master or data) are started:
 #
-# discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
+#discovery.zen.ping.unicast.hosts: ["host1", "host2:port"]
 
 # EC2 discovery allows to use AWS EC2 API in order to perform discovery.
 #
@@ -336,6 +338,17 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 # See <http://elasticsearch.org/tutorials/elasticsearch-on-ec2/>
 # for a step-by-step tutorial.
 
+# GCE discovery allows to use Google Compute Engine API in order to perform discovery.
+#
+# You have to install the cloud-gce plugin for enabling the GCE discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-gce>.
+
+# Azure discovery allows to use Azure API in order to perform discovery.
+#
+# You have to install the cloud-azure plugin for enabling the Azure discovery.
+#
+# For more information, see <https://github.com/elasticsearch/elasticsearch-cloud-azure>.
 
 ################################## Slow Log ##################################
 
@@ -365,3 +378,11 @@ http.port: <%= rubber_env.elasticsearch_http_port %>
 #monitor.jvm.gc.old.warn: 10s
 #monitor.jvm.gc.old.info: 5s
 #monitor.jvm.gc.old.debug: 2s
+
+################################## Security ################################
+
+# Uncomment if you want to enable JSONP as a valid return transport on the
+# http server. With this enabled, it may pose a security risk, so disabling
+# it unless you need it is recommended (it is disabled by default).
+#
+#http.jsonp.enable: true

--- a/templates/elasticsearch/config/rubber/rubber-elasticsearch.yml
+++ b/templates/elasticsearch/config/rubber/rubber-elasticsearch.yml
@@ -1,4 +1,5 @@
-elasticsearch_version: 0.90.10
+elasticsearch_version: 1.7.0
+elasticsearch_cluster_name: "elasticsearch_production"
 elasticsearch_data_dir: "/mnt/elasticsearch/data"
 elasticsearch_work_dir: "/mnt/elasticsearch/work"
 elasticsearch_log_dir: "/mnt/elasticsearch/logs"


### PR DESCRIPTION
This PR updates Elasticsearch to version 1.7.0.

It seems the current template assumes you are using ES with Graylog, and has env var `rubber_env.graylog_elasticsearch_index`. I've replaced this with `rubber_env.elasticsearch_cluster_name`. Please advise what we should do here.

All whitespace etc changes in the `.yml` file are coming from ES itself.
