### PR TITLE
Relax dependency on net-ssh

### DIFF
--- a/rubber.gemspec
+++ b/rubber.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'capistrano', '~> 2.12'
-  s.add_dependency 'net-ssh', '~> 2.6'
+  s.add_dependency 'net-ssh', '>= 2.6'
   s.add_dependency 'thor'
   s.add_dependency 'clamp'
   s.add_dependency 'fog', '< 2.0'


### PR DESCRIPTION
net-ssh is now in v3.0 which contains some critical fixes for Windows.

The main reason for the major bump was due to dropping support for Ruby 1.9, which is specified in their gemspec.

This is working fine for me in production.