### PR TITLE
Call to #instance_alias should be call to #name

### DIFF
--- a/lib/rubber/cloud/aws/base.rb
+++ b/lib/rubber/cloud/aws/base.rb
@@ -72,7 +72,7 @@ module Rubber
       end
 
       def before_create_instance(instance)
-        setup_security_groups(instance.instance_alias, instance.role_names)
+        setup_security_groups(instance.name, instance.role_names)
       end
 
       def after_create_instance(instance)


### PR DESCRIPTION
Fairly straightforward, it looks like I messed up AWS Classic support by attempting to call a non-existent instance_alias method when I should've just called name.  I was able to create_staging successfully on AWS Classic after making this change