### PR TITLE
Vpc external ip fixes

### DIFF
--- a/lib/rubber/recipes/rubber/setup.rb
+++ b/lib/rubber/recipes/rubber/setup.rb
@@ -599,7 +599,10 @@ namespace :rubber do
     env = rubber_cfg.environment.bind(instance_item.role_names, instance_item.name)
     if env.dns_provider
       provider = Rubber::Dns::get_provider(env.dns_provider, env)
-      provider.update(instance_item.name, instance_item.external_ip)
+
+      if instance_item.external_ip && (instance_item.external_ip.length > 0)
+        provider.update(instance_item.name, instance_item.external_ip)
+      end
 
       # add the ip aliases for web tools hosts so we can map internal tools
       # to their own vhost to make proxying easier (rewriting url paths for

--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -122,7 +122,13 @@ namespace :rubber do
       # we don't mount/format at this time if we are doing a RAID array
       if vol_spec['mount'] && vol_spec['filesystem']
         # then format/mount/etc if we don't have an entry in hosts file
-        task :_setup_volume, :hosts => ic.external_ip do
+        if ic.external_ip && (ic.external_ip.length > 0)
+          host = ic.external_ip
+        else
+          host = ic.internal_ip
+        end
+
+        task :_setup_volume, :hosts => host do
           rubber.sudo_script 'setup_volume', <<-ENDSCRIPT
             # Make sure the newly added volume was found.
             rescan-scsi-bus || true


### PR DESCRIPTION
This fixes two issues with VPC support that I've come across, both related to the lack of external IPs on instances in a private VPC subnet:

- Only update DNS aliases for instances if they actually have an external ip
- Use the internal IP as a host filter if there is no external IP