### PR TITLE
Fix for create instance without VPC_ID

### DIFF
--- a/lib/rubber/cloud/fog.rb
+++ b/lib/rubber/cloud/fog.rb
@@ -63,8 +63,8 @@ module Rubber
         compute_provider.servers.get(instance.instance_id).start
       end
 
-      def create_static_ip
-        address = compute_provider.addresses.create
+      def create_static_ip(domain = 'standard')
+        address = compute_provider.addresses.create(domain: domain)
 
         address.public_ip
       end

--- a/lib/rubber/recipes/rubber/instances.rb
+++ b/lib/rubber/recipes/rubber/instances.rb
@@ -333,7 +333,7 @@ namespace :rubber do
       instance_alias,
       ami,
       ami_type,
-      fog_options[:vpc_id] ? security_groups : [],
+      fog_options[:vpc_id] ? [] : security_groups,
       availability_zone,
       region,
       fog_options

--- a/lib/rubber/recipes/rubber/static_ips.rb
+++ b/lib/rubber/recipes/rubber/static_ips.rb
@@ -14,7 +14,7 @@ namespace :rubber do
         # first allocate the static ip if we don't have a global record (artifacts) for it
         if ! ip
           logger.info "Allocating static IP for #{ic.full_name}"
-          ip = allocate_static_ip()
+          ip = allocate_static_ip(ic)
           artifacts['static_ips'][ic.name] = ip
           rubber_instances.save
         end
@@ -166,8 +166,8 @@ namespace :rubber do
     logger.info "Run 'cap rubber:describe_static_ips' to check the allocated ones"
   end
 
-  def allocate_static_ip
-    ip = cloud.create_static_ip()
+  def allocate_static_ip(instance)
+    ip = cloud.create_static_ip(instance.vpc_id ? 'vpc' : 'standard')
     fatal "Failed to allocate static ip" if ip.nil?
     return ip
   end


### PR DESCRIPTION
While create instance we should pass empty security groups when VPC_ID exists - currently we're doing the opposite and thus that EC2-Classic instances end with only a default security group.