### PR TITLE
Improved detaching & destroying AWS volumes

### DIFF
--- a/lib/rubber/cloud/fog.rb
+++ b/lib/rubber/cloud/fog.rb
@@ -144,6 +144,10 @@ module Rubber
         # No-op by default.
       end
 
+      def detach_volume(volume_id)
+        # No-op by default.
+      end
+
       def before_destroy_volume(volume_id)
         # No-op by default.
       end

--- a/lib/rubber/recipes/rubber/volumes.rb
+++ b/lib/rubber/recipes/rubber/volumes.rb
@@ -418,29 +418,19 @@ namespace :rubber do
     logger.info "Detaching volume #{volume_id}"
     cloud.detach_volume(volume_id) rescue logger.info("Volume was not attached")
 
-    print "Waiting for volume to detach"
-    while true do
-      print "."
-      sleep 2
-      volume = cloud.describe_volumes(volume_id).first
-      status = volume && volume[:attachment_status]
-      break if !status || status == "detached"
-    end
-    print "\n"
-
     logger.info "Detaching volume #{volume_id} from rubber instances file"
     rubber_instances.each do |ic|
       ic.volumes.delete(volume_id) if ic.volumes
     end
     rubber_instances.save
-
   end
-  
+
   def destroy_volume(volume_id)
+    logger.info "Detaching volume #{volume_id}"
     cloud.before_destroy_volume(volume_id)
 
     logger.info "Deleting volume #{volume_id}"
-    cloud.destroy_volume(volume_id) rescue logger.info("Volume did not exist in cloud")
+    cloud.destroy_volume(volume_id) # rescue logger.info("Volume did not exist in cloud")
 
     cloud.after_destroy_volume(volume_id)
 


### PR DESCRIPTION
So it seems that detaching & destroying AWS volumes was a bit buggy - there wasn't any `detach_volume` method even though `rubber:detach_volume` recipe is using it (it was throwing an error after I turned off rescue). I added missing method + used it in `before_destroy_volume` to detach volume before destroying it - previously removing wasn't work correctly because volume was still attached (it usually takes couple seconds before it's available) to an instance when we tried remove it.