### PR TITLE
Fix deploy instance storage check

### DIFF
--- a/lib/rubber/configuration/configuration_storage.rb
+++ b/lib/rubber/configuration/configuration_storage.rb
@@ -26,6 +26,10 @@ module Rubber
         @path = path
       end
 
+      def stored_locally?
+        false
+      end
+
       private
 
       def load_from_io(io)

--- a/lib/rubber/configuration/file_configuration_storage.rb
+++ b/lib/rubber/configuration/file_configuration_storage.rb
@@ -14,6 +14,10 @@ module Rubber
           File.open(path, 'w') { |f| save_to_io(f) }
         end
       end
+
+      def stored_locally?
+        true
+      end
     end
   end
 end

--- a/lib/rubber/recipes/rubber/deploy.rb
+++ b/lib/rubber/recipes/rubber/deploy.rb
@@ -90,13 +90,13 @@ namespace :rubber do
         push_files = rubber_cfg.environment.config_files
 
         # If we're using a local instance file, push that up.  This isn't necessary when storing in S3 or SimpleDB.
-        if rubber_instances.instance_storage =~ /^file:(.*)/
-          location = $1
+        if rubber_instances.configuration_storage.stored_locally?
+          location = rubber_instances.configuration_storage.path
           push_files << location
         end
 
         push_files.each do |file|
-          dest_file = file.sub(/^#{Rubber.root}\/?/, '')
+          dest_file = file.sub(/^file:#{Rubber.root}\/?/, '')
           put(File.read(file), File.join(path, dest_file), :mode => "+r")
         end
       end

--- a/test/configuration/file_configuration_storage_test.rb
+++ b/test/configuration/file_configuration_storage_test.rb
@@ -18,6 +18,10 @@ class Rubber::Configuration::FileConfigurationStorageTest < Test::Unit::TestCase
     FileUtils.remove_entry_secure @tmpdir
   end
 
+  should "indicate that it's stored locally" do
+    assert @storage.stored_locally?
+  end
+
   should "load configuration from a file" do
     FileUtils.cp fixture_file("configuration/instance-test.yml"), @config_file
     @storage.load

--- a/test/configuration/s3_configuration_storage_test.rb
+++ b/test/configuration/s3_configuration_storage_test.rb
@@ -22,6 +22,10 @@ class Rubber::Configuration::S3ConfigurationStorageTest < Test::Unit::TestCase
     @storage = S3ConfigurationStorage.new @cluster, File.join(@bucket, @key)
   end
 
+  should "not indicate that it's stored locally" do
+    assert !@storage.stored_locally?
+  end
+
   should "load configuration from an s3 object" do
     Rubber.cloud.storage(@bucket).store(
       @key,

--- a/test/configuration/table_configuration_storage_test.rb
+++ b/test/configuration/table_configuration_storage_test.rb
@@ -14,9 +14,6 @@ class Rubber::Configuration::TableConfigurationStorageTest < Test::Unit::TestCas
     # cloud data
     Rubber.cloud.table_store(@key).ensure_table_key
 
-    # Fog doesn't have a mock implementation for SimpleDB select yet
-    stub_simple_db_select
-
     @items = {}
     @artifacts = {}
 
@@ -24,7 +21,14 @@ class Rubber::Configuration::TableConfigurationStorageTest < Test::Unit::TestCas
     @storage = TableConfigurationStorage.new @cluster, @key
   end
 
+  should "not indicate that it's stored locally" do
+    assert !@storage.stored_locally?
+  end
+
   should "load configuration from a SimpleDB table" do
+    # Fog doesn't have a mock implementation for SimpleDB select yet
+    stub_simple_db_select
+
     fixture_file_array.each do |node|
       if node.is_a?(InstanceItem)
         Rubber.cloud.table_store(@key).put(node.name, node.to_hash)
@@ -44,6 +48,9 @@ class Rubber::Configuration::TableConfigurationStorageTest < Test::Unit::TestCas
   end
 
   should "save configuration to a SimpleDB table" do
+    # Fog doesn't have a mock implementation for SimpleDB select yet
+    stub_simple_db_select
+
     @cluster.items["app01"] = InstanceItem.new "app01",
                                                "rubber.test",
                                                [RoleItem.new("app")],


### PR DESCRIPTION
Fixes an issue currently in master resulting from my recent configuration refactoring.  This replaces an old reference to `instance_storage` in the `deploy.rb` recipe