### PR TITLE
Storage configuration path doesn't actually have "file:" in it

### DIFF
--- a/lib/rubber/recipes/rubber/deploy.rb
+++ b/lib/rubber/recipes/rubber/deploy.rb
@@ -96,7 +96,7 @@ namespace :rubber do
         end
 
         push_files.each do |file|
-          dest_file = file.sub(/^file:#{Rubber.root}\/?/, '')
+          dest_file = file.sub(/^#{Rubber.root}\/?/, '')
           put(File.read(file), File.join(path, dest_file), :mode => "+r")
         end
       end


### PR DESCRIPTION
I made a small mistake in my last PR  - the configuration storage path doesn't actually start with `file:`.  I didn't notice in my testing because the configuration deployment i tested with had the instance file checked in to source control, so the deploy still went as expected, but I noticed after the fact that the instance file had been uploaded to the absolute path on my local machine.  This should fix that.